### PR TITLE
Separate unit tests from VS Code integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Run tests (Linux)
-      run: xvfb-run -a npm test
+      run: xvfb-run -a npm run test:integration
       if: runner.os == 'Linux'
     - name: Run tests (non-Linux)
-      run: npm test
+      run: npm run test:integration
       if: runner.os != 'Linux'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@
 1. `npm run compile`
 2. `npm run lint`
 3. `npm run copy-fixtures`
-4. `npm test` (when environment supports VS Code extension test runtime)
+4. `npm test` — unit tests only, no VS Code runtime required
+5. `npm run test:integration` — full tests including VS Code integration tests (requires VS Code runtime)
 
 ## Repository conventions
 - Use TypeScript and existing coding style in `src/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@vscode/test-cli": "0.0.12",
         "@vscode/test-electron": "2.5.2",
         "eslint": "10.2.0",
+        "mocha": "11.7.5",
         "typescript": "5.9.3",
         "typescript-eslint": "8.58.2"
       },

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "copy-fixtures": "node ./scripts/copy-fixtures.js",
     "lint": "eslint src",
     "pretest": "npm run compile && npm run copy-fixtures && npm run lint",
-    "test": "mocha --ui tdd out/test/converter.test.js",
-    "pretest:integration": "npm run compile && npm run copy-fixtures && npm run lint",
+    "test": "mocha --ui tdd 'out/test/unit/**/*.test.js'",
+    "pretest:integration": "npm run pretest",
     "test:integration": "vscode-test"
   },
   "dependencies": {
@@ -107,6 +107,7 @@
     "@vscode/test-cli": "0.0.12",
     "@vscode/test-electron": "2.5.2",
     "eslint": "10.2.0",
+    "mocha": "11.7.5",
     "typescript": "5.9.3",
     "typescript-eslint": "8.58.2"
   }

--- a/package.json
+++ b/package.json
@@ -87,11 +87,13 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "copy-fixtures": "node ./scripts/copy-fixtures.js",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run copy-fixtures && npm run lint",
+    "copy-fixtures": "node ./scripts/copy-fixtures.js",
     "lint": "eslint src",
-    "test": "vscode-test"
+    "pretest": "npm run compile && npm run copy-fixtures && npm run lint",
+    "test": "mocha --ui tdd out/test/converter.test.js",
+    "pretest:integration": "npm run compile && npm run copy-fixtures && npm run lint",
+    "test:integration": "vscode-test"
   },
   "dependencies": {
     "fast-xml-parser": "5.6.0",

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -9,7 +9,7 @@ suite('Extension Test Suite', () => {
   const formatOfFixture = (fixture: string): string => path.extname(fixture).slice(1).toUpperCase();
 
   const readFixture = (filename: string): string =>
-    fs.readFileSync(path.join(__dirname, 'fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
+    fs.readFileSync(path.join(__dirname, '../fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
 
   const openEditorWithContent = async (content: string): Promise<vscode.TextEditor> => {
     const doc = await vscode.workspace.openTextDocument({ content, language: 'plaintext' });

--- a/src/test/unit/converter.test.ts
+++ b/src/test/unit/converter.test.ts
@@ -2,12 +2,12 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { SupportedFormat } from '../converter';
-import { convert } from '../converter';
+import type { SupportedFormat } from '../../converter';
+import { convert } from '../../converter';
 
 suite('Converter Test Suite', () => {
   const readFixture = (filename: string): string =>
-    fs.readFileSync(path.join(__dirname, 'fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
+    fs.readFileSync(path.join(__dirname, '../fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
 
   const fixtures = {
     object: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Separated unit and integration test execution into distinct npm scripts.
  * Updated CI workflow to run integration tests via `npm run test:integration`.

* **Documentation**
  * Clarified testing procedures to distinguish between unit tests and VS Code integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->