### PR TITLE
Fix YAML flow style input being misdetected as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
   - Command Palette
   - Editor right-click context menu
 - Automatic input format detection:
-  - Content starting with `{` or `[` is parsed as JSON
   - Content starting with `<` is parsed as XML
+  - Content starting with `{` or `[` is parsed as JSON, or YAML if JSON parsing fails (e.g. YAML flow style)
   - All other content is parsed as YAML
 - Convert the entire document, or just the selected text if a selection is active
 - Output formatting is configurable (pretty / minified)

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -13,7 +13,12 @@ const INDENT_SIZE = 2;
 export const convert = (content: string, to: SupportedFormat, options: ConvertOptions): string => {
   let intermediate: unknown;
   if (content.startsWith('{') || content.startsWith('[')) {
-    intermediate = JSON.parse(content);
+    try {
+      intermediate = JSON.parse(content);
+    } catch {
+      // YAML flow style also starts with '{' or '[', e.g. {key: value}
+      intermediate = yaml.load(content);
+    }
   } else if (content.startsWith('<')) {
     const parser = new XMLParser({
       ignoreAttributes: false,

--- a/src/test/unit/converter.test.ts
+++ b/src/test/unit/converter.test.ts
@@ -68,6 +68,15 @@ suite('Converter Test Suite', () => {
     { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'JSON to YAML (minified)' },
   ]);
 
+  createTestSuite('JSON minified input', fixtures.object.json.minified, [
+    { to: 'json', minify: false, expected: fixtures.object.json.pretty, description: 'JSON minified to JSON (pretty)' },
+    { to: 'json', minify: true, expected: fixtures.object.json.minified, description: 'JSON minified to JSON (minified)' },
+    { to: 'xml', minify: false, expected: fixtures.object.xml.pretty, description: 'JSON minified to XML (pretty)' },
+    { to: 'xml', minify: true, expected: fixtures.object.xml.minified, description: 'JSON minified to XML (minified)' },
+    { to: 'yaml', minify: false, expected: fixtures.object.yaml.pretty, description: 'JSON minified to YAML (pretty)' },
+    { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'JSON minified to YAML (minified)' },
+  ]);
+
   createTestSuite('JSON array input', fixtures.array.json.pretty, [
     { to: 'json', minify: false, expected: fixtures.array.json.pretty, description: 'Array to JSON (pretty)' },
     { to: 'json', minify: true, expected: fixtures.array.json.minified, description: 'Array to JSON (minified)' },
@@ -86,6 +95,15 @@ suite('Converter Test Suite', () => {
     { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'XML to YAML (minified)' },
   ]);
 
+  createTestSuite('XML minified input', fixtures.object.xml.minified, [
+    { to: 'json', minify: false, expected: fixtures.object.json.pretty, description: 'XML minified to JSON (pretty)' },
+    { to: 'json', minify: true, expected: fixtures.object.json.minified, description: 'XML minified to JSON (minified)' },
+    { to: 'xml', minify: false, expected: fixtures.object.xml.pretty, description: 'XML minified to XML (pretty)' },
+    { to: 'xml', minify: true, expected: fixtures.object.xml.minified, description: 'XML minified to XML (minified)' },
+    { to: 'yaml', minify: false, expected: fixtures.object.yaml.pretty, description: 'XML minified to YAML (pretty)' },
+    { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'XML minified to YAML (minified)' },
+  ]);
+
   createTestSuite('YAML input', fixtures.object.yaml.pretty, [
     { to: 'json', minify: false, expected: fixtures.object.json.pretty, description: 'YAML to JSON (pretty)' },
     { to: 'json', minify: true, expected: fixtures.object.json.minified, description: 'YAML to JSON (minified)' },
@@ -93,6 +111,15 @@ suite('Converter Test Suite', () => {
     { to: 'xml', minify: true, expected: fixtures.object.xml.minified, description: 'YAML to XML (minified)' },
     { to: 'yaml', minify: false, expected: fixtures.object.yaml.pretty, description: 'YAML to YAML (pretty)' },
     { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'YAML to YAML (minified)' },
+  ]);
+
+  createTestSuite('YAML minified input', fixtures.object.yaml.minified, [
+    { to: 'json', minify: false, expected: fixtures.object.json.pretty, description: 'YAML minified to JSON (pretty)' },
+    { to: 'json', minify: true, expected: fixtures.object.json.minified, description: 'YAML minified to JSON (minified)' },
+    { to: 'xml', minify: false, expected: fixtures.object.xml.pretty, description: 'YAML minified to XML (pretty)' },
+    { to: 'xml', minify: true, expected: fixtures.object.xml.minified, description: 'YAML minified to XML (minified)' },
+    { to: 'yaml', minify: false, expected: fixtures.object.yaml.pretty, description: 'YAML minified to YAML (pretty)' },
+    { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'YAML minified to YAML (minified)' },
   ]);
 
   createTestSuite('XML input with attributeNamePrefix "$"', fixtures.object.xml.pretty, [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input format detection to allow YAML flow-style syntax beginning with `{` or `[`.

* **Tests**
  * Added comprehensive test coverage for minified inputs across JSON, XML, and YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->