### PR TITLE
Add Format JSON/XML/YAML commands for same-format reformatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,9 @@
   - `xyjson.toJson`
   - `xyjson.toXml`
   - `xyjson.toYaml`
+  - `xyjson.formatJson`
+  - `xyjson.formatXml`
+  - `xyjson.formatYaml`
 - Keep user-facing behavior aligned with README settings and usage docs.
 
 ## PR/commit expectations

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
   - **XYJson: Convert to JSON** - Transform XML or YAML content to JSON
   - **XYJson: Convert to XML** - Transform JSON or YAML content to XML
   - **XYJson: Convert to YAML** - Transform JSON or XML content to YAML
+- Format commands (same-format reformatting):
+  - **XYJson: Format JSON** - Reformat JSON content (e.g. minified → pretty)
+  - **XYJson: Format XML** - Reformat XML content
+  - **XYJson: Format YAML** - Reformat YAML content
 - Available from:
   - Command Palette
   - Editor right-click context menu
@@ -32,6 +36,9 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
    - **XYJson: Convert to JSON**
    - **XYJson: Convert to XML**
    - **XYJson: Convert to YAML**
+   - **XYJson: Format JSON** (shown only when editing a JSON file)
+   - **XYJson: Format XML** (shown only when editing an XML file)
+   - **XYJson: Format YAML** (shown only when editing a YAML file)
 
 If text is selected, only the selection is replaced with the converted result.
 If nothing is selected, the entire document is replaced.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,18 @@
       {
         "command": "xyjson.toYaml",
         "title": "XYJson: Convert to YAML"
+      },
+      {
+        "command": "xyjson.formatJson",
+        "title": "XYJson: Format JSON"
+      },
+      {
+        "command": "xyjson.formatXml",
+        "title": "XYJson: Format XML"
+      },
+      {
+        "command": "xyjson.formatYaml",
+        "title": "XYJson: Format YAML"
       }
     ],
     "menus": {
@@ -66,6 +78,21 @@
           "command": "xyjson.toYaml",
           "group": "xyjson",
           "when": "editorLangId == json || editorLangId == jsonc || editorLangId == xml"
+        },
+        {
+          "command": "xyjson.formatJson",
+          "group": "xyjson",
+          "when": "editorLangId == json || editorLangId == jsonc"
+        },
+        {
+          "command": "xyjson.formatXml",
+          "group": "xyjson",
+          "when": "editorLangId == xml"
+        },
+        {
+          "command": "xyjson.formatYaml",
+          "group": "xyjson",
+          "when": "editorLangId == yaml"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('xyjson.toJson', () => convertAndReplace('json')),
     vscode.commands.registerCommand('xyjson.toXml', () => convertAndReplace('xml')),
     vscode.commands.registerCommand('xyjson.toYaml', () => convertAndReplace('yaml')),
+    vscode.commands.registerCommand('xyjson.formatJson', () => convertAndReplace('json')),
+    vscode.commands.registerCommand('xyjson.formatXml', () => convertAndReplace('xml')),
+    vscode.commands.registerCommand('xyjson.formatYaml', () => convertAndReplace('yaml')),
   );
 }
 

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -64,6 +64,22 @@ suite('Extension Test Suite', () => {
     }
   });
 
+  suite('Format Commands', () => {
+    const cases = [
+      { command: 'xyjson.formatJson', input: 'json-minified.json', expectedFixture: 'json-pretty.json' },
+      { command: 'xyjson.formatXml',  input: 'xml-minified.xml',   expectedFixture: 'xml-pretty.xml'  },
+      { command: 'xyjson.formatYaml', input: 'yaml-minified.yaml', expectedFixture: 'yaml-pretty.yaml' },
+    ] as const;
+
+    for (const { command, input, expectedFixture } of cases) {
+      test(`${commandLabel(command)} reformats minified input to pretty`, async () => {
+        const editor = await openEditorWithContent(readFixture(input));
+        await vscode.commands.executeCommand(command);
+        assert.strictEqual(getEditorText(editor), readFixture(expectedFixture));
+      });
+    }
+  });
+
   suite('Minify Configuration', () => {
     const cases = [
       { command: 'xyjson.toJson', expectedFixture: 'json-minified.json' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new formatting commands—Format JSON, Format XML, and Format YAML—to reformat your documents. Access them from the command palette or editor context menu, with automatic visibility restrictions based on the file type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->