### PR TITLE
Add Format JSON/XML/YAML commands for same-format reformatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,9 @@
   - `xyjson.toJson`
   - `xyjson.toXml`
   - `xyjson.toYaml`
+  - `xyjson.formatJson`
+  - `xyjson.formatXml`
+  - `xyjson.formatYaml`
 - Keep user-facing behavior aligned with README settings and usage docs.
 
 ## PR/commit expectations

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
   - **XYJson: Convert to JSON** - Transform XML or YAML content to JSON
   - **XYJson: Convert to XML** - Transform JSON or YAML content to XML
   - **XYJson: Convert to YAML** - Transform JSON or XML content to YAML
+- Format commands (same-format reformatting):
+  - **XYJson: Format JSON** - Reformat JSON content
+  - **XYJson: Format XML** - Reformat XML content
+  - **XYJson: Format YAML** - Reformat YAML content
 - Available from:
   - Command Palette
   - Editor right-click context menu
@@ -32,6 +36,9 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
    - **XYJson: Convert to JSON**
    - **XYJson: Convert to XML**
    - **XYJson: Convert to YAML**
+   - **XYJson: Format JSON** (shown only when editing a JSON file)
+   - **XYJson: Format XML** (shown only when editing an XML file)
+   - **XYJson: Format YAML** (shown only when editing a YAML file)
 
 If text is selected, only the selection is replaced with the converted result.
 If nothing is selected, the entire document is replaced.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,18 @@
       {
         "command": "xyjson.toYaml",
         "title": "XYJson: Convert to YAML"
+      },
+      {
+        "command": "xyjson.formatJson",
+        "title": "XYJson: Format JSON"
+      },
+      {
+        "command": "xyjson.formatXml",
+        "title": "XYJson: Format XML"
+      },
+      {
+        "command": "xyjson.formatYaml",
+        "title": "XYJson: Format YAML"
       }
     ],
     "menus": {
@@ -66,6 +78,21 @@
           "command": "xyjson.toYaml",
           "group": "xyjson",
           "when": "editorLangId == json || editorLangId == jsonc || editorLangId == xml"
+        },
+        {
+          "command": "xyjson.formatJson",
+          "group": "xyjson",
+          "when": "editorLangId == json || editorLangId == jsonc"
+        },
+        {
+          "command": "xyjson.formatXml",
+          "group": "xyjson",
+          "when": "editorLangId == xml"
+        },
+        {
+          "command": "xyjson.formatYaml",
+          "group": "xyjson",
+          "when": "editorLangId == yaml"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,11 +2,14 @@ import * as vscode from 'vscode';
 
 import { convert, SupportedFormat } from './converter';
 
-async function convertAndReplace(to: SupportedFormat): Promise<void> {
+type Action = 'convert' | 'format';
+
+async function convertAndReplace(to: SupportedFormat, action: Action): Promise<void> {
   const editor = vscode.window.activeTextEditor;
+  const label = action === 'format' ? 'Formatting' : 'Conversion';
 
   if (!editor) {
-    vscode.window.showErrorMessage('Conversion failed: No active editor found');
+    vscode.window.showErrorMessage(`${label} failed: No active editor found`);
     return;
   }
 
@@ -19,7 +22,7 @@ async function convertAndReplace(to: SupportedFormat): Promise<void> {
     : document.getText().trim();
 
   if (!content) {
-    vscode.window.showErrorMessage('Conversion failed: Document is empty');
+    vscode.window.showErrorMessage(`${label} failed: Document is empty`);
     return;
   }
 
@@ -42,18 +45,23 @@ async function convertAndReplace(to: SupportedFormat): Promise<void> {
     });
 
     vscode.window.showInformationMessage(
-      `Converted to ${to} (${minify ? 'minified' : 'formatted'})`,
+      action === 'format'
+        ? `Formatted ${to} (${minify ? 'minified' : 'formatted'})`
+        : `Converted to ${to} (${minify ? 'minified' : 'formatted'})`,
     );
   } catch (err) {
-    vscode.window.showErrorMessage(`Conversion failed: ${err instanceof Error ? err.message : String(err)}`);
+    vscode.window.showErrorMessage(`${label} failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand('xyjson.toJson', () => convertAndReplace('json')),
-    vscode.commands.registerCommand('xyjson.toXml', () => convertAndReplace('xml')),
-    vscode.commands.registerCommand('xyjson.toYaml', () => convertAndReplace('yaml')),
+    vscode.commands.registerCommand('xyjson.toJson', () => convertAndReplace('json', 'convert')),
+    vscode.commands.registerCommand('xyjson.toXml', () => convertAndReplace('xml', 'convert')),
+    vscode.commands.registerCommand('xyjson.toYaml', () => convertAndReplace('yaml', 'convert')),
+    vscode.commands.registerCommand('xyjson.formatJson', () => convertAndReplace('json', 'format')),
+    vscode.commands.registerCommand('xyjson.formatXml', () => convertAndReplace('xml', 'format')),
+    vscode.commands.registerCommand('xyjson.formatYaml', () => convertAndReplace('yaml', 'format')),
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,8 +46,8 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
 
     vscode.window.showInformationMessage(
       action === 'format'
-        ? `Formatted ${to} (${minify ? 'minified' : 'formatted'})`
-        : `Converted to ${to} (${minify ? 'minified' : 'formatted'})`,
+        ? `Formatted ${to} (${minify ? 'minified' : 'pretty'})`
+        : `Converted to ${to} (${minify ? 'minified' : 'pretty'})`,
     );
   } catch (err) {
     vscode.window.showErrorMessage(`${label} failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -64,6 +64,22 @@ suite('Extension Test Suite', () => {
     }
   });
 
+  suite('Format Commands', () => {
+    const cases = [
+      { command: 'xyjson.formatJson', input: 'json-minified.json', expectedFixture: 'json-pretty.json' },
+      { command: 'xyjson.formatXml',  input: 'xml-minified.xml',   expectedFixture: 'xml-pretty.xml'  },
+      { command: 'xyjson.formatYaml', input: 'yaml-minified.yaml', expectedFixture: 'yaml-pretty.yaml' },
+    ] as const;
+
+    for (const { command, input, expectedFixture } of cases) {
+      test(`${commandLabel(command)} reformats minified input`, async () => {
+        const editor = await openEditorWithContent(readFixture(input));
+        await vscode.commands.executeCommand(command);
+        assert.strictEqual(getEditorText(editor), readFixture(expectedFixture));
+      });
+    }
+  });
+
   suite('Minify Configuration', () => {
     const cases = [
       { command: 'xyjson.toJson', expectedFixture: 'json-minified.json' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Format JSON, Format XML, and Format YAML commands to reformat files in-place; context-menu visibility is limited to the matching file type and they are distinct from conversion commands

* **Documentation**
  * Updated docs and repository instructions to include and preserve the new public format command IDs

* **Tests**
  * Added integration tests verifying each formatting command produces the expected pretty output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->