### PR TITLE
Replace xyjson.minify setting with Quick Pick dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
   - Content starting with `{` or `[` is parsed as JSON, or YAML if JSON parsing fails (e.g. YAML flow style)
   - All other content is parsed as YAML
 - Convert the entire document, or just the selected text if a selection is active
-- Output formatting is configurable (pretty / minified)
+- Output format (pretty / minified) selected via Quick Pick on each command
 
 ## Usage
 
@@ -47,7 +47,6 @@ If nothing is selected, the entire document is replaced.
 
 | Setting                         | Type    | Default | Description                                                       |
 |---------------------------------|---------|---------|-------------------------------------------------------------------|
-| `xyjson.minify`                 | boolean | `false` | Whether to minify output instead of pretty formatting.            |
 | `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML. |
 
 ## License

--- a/package.json
+++ b/package.json
@@ -98,11 +98,6 @@
     },
     "configuration": {
       "properties": {
-        "xyjson.minify": {
-          "type": "boolean",
-          "default": false,
-          "description": "Minify output instead of pretty formatting when converting XML/JSON/YAML."
-        },
         "xyjson.xmlAttributeNamePrefix": {
           "type": "string",
           "default": "@_",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,8 +26,15 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
     return;
   }
 
+  const pick = await vscode.window.showQuickPick(['Pretty', 'Minified'], {
+    placeHolder: 'Select output format',
+  });
+  if (pick === undefined) {
+    return;
+  }
+  const minify = pick === 'Minified';
+
   const config = vscode.workspace.getConfiguration('xyjson');
-  const minify = config.get<boolean>('minify', false);
   const attributeNamePrefix = config.get<string>('xmlAttributeNamePrefix', '@_');
 
   try {

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -4,6 +4,17 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 suite('Extension Test Suite', () => {
+  let quickPickResponse: string | undefined = 'Pretty';
+  const originalShowQuickPick = (vscode.window as any).showQuickPick;
+
+  suiteSetup(() => {
+    (vscode.window as any).showQuickPick = async () => quickPickResponse;
+  });
+
+  suiteTeardown(() => {
+    (vscode.window as any).showQuickPick = originalShowQuickPick;
+  });
+
   const commandLabel = (command: string): string => command.replace(/^xyjson\./, '');
 
   const formatOfFixture = (fixture: string): string => path.extname(fixture).slice(1).toUpperCase();
@@ -20,12 +31,6 @@ suite('Extension Test Suite', () => {
     return editor.document.getText().replace(/\r\n/g, '\n');
   };
 
-  const setMinify = async (value: boolean): Promise<void> => {
-    await vscode.workspace
-      .getConfiguration('xyjson')
-      .update('minify', value, vscode.ConfigurationTarget.Global);
-  };
-
   const setAttributeNamePrefix = async (value: string): Promise<void> => {
     await vscode.workspace
       .getConfiguration('xyjson')
@@ -33,8 +38,8 @@ suite('Extension Test Suite', () => {
   };
 
   teardown(async () => {
+    quickPickResponse = 'Pretty';
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-    await setMinify(false);
     await setAttributeNamePrefix('@_');
   });
 
@@ -80,7 +85,7 @@ suite('Extension Test Suite', () => {
     }
   });
 
-  suite('Minify Configuration', () => {
+  suite('Output Format Selection', () => {
     const cases = [
       { command: 'xyjson.toJson', expectedFixture: 'json-minified.json' },
       { command: 'xyjson.toXml', expectedFixture: 'xml-minified.xml' },
@@ -88,13 +93,21 @@ suite('Extension Test Suite', () => {
     ] as const;
 
     for (const c of cases) {
-      test(`${commandLabel(c.command)} produces minified output when xyjson.minify is true`, async () => {
-        await setMinify(true);
+      test(`${commandLabel(c.command)} produces minified output when "Minified" is selected`, async () => {
+        quickPickResponse = 'Minified';
         const editor = await openEditorWithContent(readFixture('json-pretty.json'));
         await vscode.commands.executeCommand(c.command);
         assert.strictEqual(getEditorText(editor), readFixture(c.expectedFixture));
       });
     }
+
+    test('cancelling Quick Pick leaves document unchanged', async () => {
+      quickPickResponse = undefined;
+      const content = readFixture('json-pretty.json');
+      const editor = await openEditorWithContent(content);
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getEditorText(editor), content);
+    });
   });
 
   suite('AttributeNamePrefix Configuration', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Output format (pretty/minified) is now selected per-command via Quick Pick dialog instead of using a global configuration setting.

* **Documentation**
  * Updated README to reflect per-command output selection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->