### PR TITLE
Open conversion result in a new tab instead of overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,31 @@
 
 Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
 
-- Convert between formats with one command
-- Pretty format or minify output
+- Convert between formats — result opens in a new tab
+- Reformat documents in place
+- Pretty or minified output via Quick Pick
 - Works from Command Palette and right-click menu
 - Automatic input format detection
 
 ## Features
 
-- Conversion commands:
+- Conversion commands — open the result in a new tab, leaving the original untouched:
   - **XYJson: Convert to JSON** - Transform XML or YAML content to JSON
   - **XYJson: Convert to XML** - Transform JSON or YAML content to XML
   - **XYJson: Convert to YAML** - Transform JSON or XML content to YAML
-- Format commands (same-format reformatting):
+- Format commands — reformat the current document in place:
   - **XYJson: Format JSON** - Reformat JSON content
   - **XYJson: Format XML** - Reformat XML content
   - **XYJson: Format YAML** - Reformat YAML content
 - Available from:
   - Command Palette
   - Editor right-click context menu
+- Works on the entire document, or just the selected text if a selection is active
+- Output format (pretty / minified) selected via Quick Pick on each command
 - Automatic input format detection:
   - Content starting with `<` is parsed as XML
   - Content starting with `{` or `[` is parsed as JSON, or YAML if JSON parsing fails (e.g. YAML flow style)
   - All other content is parsed as YAML
-- Convert the entire document, or just the selected text if a selection is active
-- Output format (pretty / minified) selected via Quick Pick on each command
 
 ## Usage
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,16 +47,20 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
   try {
     const result = convert(content, to, { minify, attributeNamePrefix });
 
-    const replaceRange = hasSelection
-      ? selection
-      : new vscode.Range(
-          document.lineAt(0).range.start,
-          document.lineAt(document.lineCount - 1).range.end,
-        );
-
-    await editor.edit((editBuilder) => {
-      editBuilder.replace(replaceRange, result);
-    });
+    if (action === 'convert') {
+      const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
+      await vscode.window.showTextDocument(doc, { preview: false });
+    } else {
+      const replaceRange = hasSelection
+        ? selection
+        : new vscode.Range(
+            document.lineAt(0).range.start,
+            document.lineAt(document.lineCount - 1).range.end,
+          );
+      await editor.edit((editBuilder) => {
+        editBuilder.replace(replaceRange, result);
+      });
+    }
 
     vscode.window.showInformationMessage(
       action === 'format'

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -31,6 +31,8 @@ suite('Extension Test Suite', () => {
     return editor.document.getText().replace(/\r\n/g, '\n');
   };
 
+  const getActiveEditorText = (): string => getEditorText(vscode.window.activeTextEditor!);
+
   const setAttributeNamePrefix = async (value: string): Promise<void> => {
     await vscode.workspace
       .getConfiguration('xyjson')
@@ -60,9 +62,9 @@ suite('Extension Test Suite', () => {
       suite(`${commandLabel(c.command)} command`, () => {
         for (const inputFixture of inputFixtures) {
           test(`converts ${formatOfFixture(inputFixture)} to ${formatOfFixture(c.expectedFixture)}`, async () => {
-            const editor = await openEditorWithContent(readFixture(inputFixture));
+            await openEditorWithContent(readFixture(inputFixture));
             await vscode.commands.executeCommand(c.command);
-            assert.strictEqual(getEditorText(editor), readFixture(c.expectedFixture));
+            assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
           });
         }
       });
@@ -95,9 +97,9 @@ suite('Extension Test Suite', () => {
     for (const c of cases) {
       test(`${commandLabel(c.command)} produces minified output when "Minified" is selected`, async () => {
         quickPickResponse = { label: 'Minified' };
-        const editor = await openEditorWithContent(readFixture('json-pretty.json'));
+        await openEditorWithContent(readFixture('json-pretty.json'));
         await vscode.commands.executeCommand(c.command);
-        assert.strictEqual(getEditorText(editor), readFixture(c.expectedFixture));
+        assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
       });
     }
 
@@ -120,20 +122,20 @@ suite('Extension Test Suite', () => {
     for (const { prefix, expectedKey } of cases) {
       test(`toJson maps attribute key with prefix "${prefix}"`, async () => {
         await setAttributeNamePrefix(prefix);
-        const editor = await openEditorWithContent(readFixture('xml-pretty.xml'));
+        await openEditorWithContent(readFixture('xml-pretty.xml'));
         await vscode.commands.executeCommand('xyjson.toJson');
-        const parsed = JSON.parse(getEditorText(editor));
+        const parsed = JSON.parse(getActiveEditorText());
         assert.strictEqual(parsed.profiles[expectedKey], '1');
       });
     }
 
     test('toXml round-trip preserves attribute with custom prefix "$"', async () => {
       await setAttributeNamePrefix('$');
-      const editor = await openEditorWithContent(readFixture('xml-pretty.xml'));
+      await openEditorWithContent(readFixture('xml-pretty.xml'));
       await vscode.commands.executeCommand('xyjson.toXml');
-      const first = getEditorText(editor);
+      const first = getActiveEditorText();
       await vscode.commands.executeCommand('xyjson.toXml');
-      assert.strictEqual(getEditorText(editor), first);
+      assert.strictEqual(getActiveEditorText(), first);
     });
   });
 
@@ -150,18 +152,15 @@ suite('Extension Test Suite', () => {
 
       await vscode.commands.executeCommand('xyjson.toYaml');
 
-      const text = getEditorText(editor);
-      assert.ok(text.startsWith(prefix), 'prefix should be unchanged');
-      assert.ok(text.endsWith(suffix), 'suffix should be unchanged');
-      const converted = text.slice(prefix.length, text.length - suffix.length);
-      assert.strictEqual(converted, readFixture('yaml-pretty.yaml'));
+      assert.strictEqual(getEditorText(editor), prefix + jsonSnippet + suffix);
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
     });
 
     test('converts entire document when selection is empty', async () => {
-      const editor = await openEditorWithContent(readFixture('json-pretty.json'));
+      await openEditorWithContent(readFixture('json-pretty.json'));
       // selection is empty by default
       await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getEditorText(editor), readFixture('yaml-pretty.yaml'));
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversion commands now open converted output in a new tab while preserving original content

* **Documentation**
  * Updated feature documentation to clarify conversion vs. formatting command behaviors
  * Emphasized output format selection via Quick Pick interface

* **Tests**
  * Updated integration tests to align with new conversion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->