### PR TITLE
Guard against stale editor after Quick Pick closes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,10 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
       const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
       await vscode.window.showTextDocument(doc, { preview: false });
     } else {
+      if (editor.document.isClosed || editor !== vscode.window.activeTextEditor) {
+        vscode.window.showErrorMessage(`${label} failed: active editor changed`);
+        return;
+      }
       const replaceRange = hasSelection
         ? selection
         : new vscode.Range(

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -196,6 +196,24 @@ suite('Extension Test Suite', () => {
       });
     }
 
+    test('format command leaves document unchanged when active editor changes during Quick Pick', async () => {
+      const content = readFixture('json-minified.json');
+      const editor = await openEditorWithContent(content);
+      const suiteMock = (vscode.window as any).showQuickPick;
+
+      (vscode.window as any).showQuickPick = async () => {
+        await openEditorWithContent('other content');
+        return { label: 'Pretty' };
+      };
+
+      try {
+        await vscode.commands.executeCommand('xyjson.formatJson');
+        assert.strictEqual(getEditorText(editor), content);
+      } finally {
+        (vscode.window as any).showQuickPick = suiteMock;
+      }
+    });
+
     test('format command leaves document unchanged when document is readonly', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed a race condition where formatting operations could unintentionally apply to the wrong document if the active editor changed during processing. The extension now validates that the active editor remains unchanged before applying formatting changes. If an editor change is detected, an error message is displayed and the operation is aborted, ensuring edits are applied safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->