### PR TITLE
Add xyjson.indentSize setting to configure indentation size

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Convert **XML ⇄ YAML ⇄ JSON** directly inside VS Code.
 
 ## Settings
 
-| Setting                         | Type    | Default | Description                                                       |
-|---------------------------------|---------|---------|-------------------------------------------------------------------|
-| `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML. |
+| Setting                         | Type    | Default | Description                                                                                        |
+|---------------------------------|---------|---------|----------------------------------------------------------------------------------------------------|
+| `xyjson.indentSize`             | integer | `2`     | Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output. Min: 1, Max: 8. |
+| `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML.                                  |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,13 @@
     },
     "configuration": {
       "properties": {
+        "xyjson.indentSize": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 8,
+          "description": "Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output."
+        },
         "xyjson.xmlAttributeNamePrefix": {
           "type": "string",
           "default": "@_",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -5,10 +5,9 @@ export type SupportedFormat = 'json' | 'xml' | 'yaml';
 
 type ConvertOptions = {
   minify: boolean;
+  indentSize: number;
   attributeNamePrefix: string;
 };
-
-const INDENT_SIZE = 2;
 
 export const convert = (content: string, to: SupportedFormat, options: ConvertOptions): string => {
   let intermediate: unknown;
@@ -32,11 +31,12 @@ export const convert = (content: string, to: SupportedFormat, options: ConvertOp
   if (to === 'json') {
     return options.minify
       ? JSON.stringify(intermediate)
-      : JSON.stringify(intermediate, null, INDENT_SIZE) + '\n';
+      : JSON.stringify(intermediate, null, options.indentSize) + '\n';
   }
 
   if (to === 'xml') {
     const builder = new XMLBuilder({
+      indentBy: ' '.repeat(options.indentSize),
       ignoreAttributes: false,
       attributeNamePrefix: options.attributeNamePrefix,
       format: !options.minify,
@@ -45,7 +45,7 @@ export const convert = (content: string, to: SupportedFormat, options: ConvertOp
   }
 
   return yaml.dump(intermediate, {
-    indent: INDENT_SIZE,
+    indent: options.indentSize,
     lineWidth: -1,
     noRefs: true,
     flowLevel: options.minify ? 0 : -1,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
-import { convert, SupportedFormat } from './converter';
+import type { SupportedFormat } from './converter';
+import { convert } from './converter';
 
 type Action = 'convert' | 'format';
 
@@ -41,10 +42,11 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
   const minify = pick.label === 'Minified';
 
   const config = vscode.workspace.getConfiguration('xyjson');
+  const indentSize = config.get<number>('indentSize', 2);
   const attributeNamePrefix = config.get<string>('xmlAttributeNamePrefix', '@_');
 
   try {
-    const result = convert(content, to, { minify, attributeNamePrefix });
+    const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
 
     if (action === 'convert') {
       const doc = await vscode.workspace.openTextDocument({ content: result, language: to });

--- a/src/test/fixtures/json-4-space.json
+++ b/src/test/fixtures/json-4-space.json
@@ -1,0 +1,7 @@
+{
+    "profiles": {
+        "name": "test",
+        "value": 123,
+        "@_id": "1"
+    }
+}

--- a/src/test/fixtures/xml-4-space.xml
+++ b/src/test/fixtures/xml-4-space.xml
@@ -1,0 +1,4 @@
+<profiles id="1">
+    <name>test</name>
+    <value>123</value>
+</profiles>

--- a/src/test/fixtures/yaml-4-space.yaml
+++ b/src/test/fixtures/yaml-4-space.yaml
@@ -1,0 +1,4 @@
+profiles:
+    name: test
+    value: 123
+    '@_id': '1'

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -33,6 +33,12 @@ suite('Extension Test Suite', () => {
 
   const getActiveEditorText = (): string => getEditorText(vscode.window.activeTextEditor!);
 
+  const setIndentSize = async (value: number): Promise<void> => {
+    await vscode.workspace
+      .getConfiguration('xyjson')
+      .update('indentSize', value, vscode.ConfigurationTarget.Global);
+  };
+
   const setAttributeNamePrefix = async (value: string): Promise<void> => {
     await vscode.workspace
       .getConfiguration('xyjson')
@@ -42,6 +48,7 @@ suite('Extension Test Suite', () => {
   teardown(async () => {
     quickPickResponse = { label: 'Pretty' };
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    await setIndentSize(2);
     await setAttributeNamePrefix('@_');
   });
 
@@ -110,6 +117,23 @@ suite('Extension Test Suite', () => {
       await vscode.commands.executeCommand('xyjson.toYaml');
       assert.strictEqual(getEditorText(editor), content);
     });
+  });
+
+  suite('IndentSize Configuration', () => {
+    const cases = [
+      { command: 'xyjson.toJson', expectedFixture: 'json-4-space.json' },
+      { command: 'xyjson.toYaml', expectedFixture: 'yaml-4-space.yaml' },
+      { command: 'xyjson.toXml', expectedFixture: 'xml-4-space.xml' },
+    ] as const;
+
+    for (const { command, expectedFixture } of cases) {
+      test(`${commandLabel(command)} produces 4-space indented output when xyjson.indentSize is 4`, async () => {
+        await setIndentSize(4);
+        await openEditorWithContent(readFixture('json-pretty.json'));
+        await vscode.commands.executeCommand(command);
+        assert.strictEqual(getActiveEditorText(), readFixture(expectedFixture));
+      });
+    }
   });
 
   suite('AttributeNamePrefix Configuration', () => {

--- a/src/test/unit/converter.test.ts
+++ b/src/test/unit/converter.test.ts
@@ -14,14 +14,17 @@ suite('Converter Test Suite', () => {
       json: {
         pretty: readFixture('json-pretty.json'),
         minified: readFixture('json-minified.json'),
+        '4-space': readFixture('json-4-space.json'),
       },
       xml: {
         pretty: readFixture('xml-pretty.xml'),
         minified: readFixture('xml-minified.xml'),
+        '4-space': readFixture('xml-4-space.xml'),
       },
       yaml: {
         pretty: readFixture('yaml-pretty.yaml'),
         minified: readFixture('yaml-minified.yaml'),
+        '4-space': readFixture('yaml-4-space.yaml'),
       },
     },
     array: {
@@ -43,6 +46,7 @@ suite('Converter Test Suite', () => {
   type TestCase = {
     to: SupportedFormat;
     minify: boolean;
+    indentSize?: number;
     attributeNamePrefix?: string;
     expected: string;
     description: string;
@@ -50,9 +54,9 @@ suite('Converter Test Suite', () => {
 
   const createTestSuite = (suiteName: string, input: string, testCases: TestCase[]) => {
     suite(suiteName, () => {
-      for (const { to, minify, attributeNamePrefix = '@_', expected, description } of testCases) {
+      for (const { to, minify, indentSize = 2, attributeNamePrefix = '@_', expected, description } of testCases) {
         test(description, () => {
-          const actual = convert(input, to, { minify, attributeNamePrefix });
+          const actual = convert(input, to, { minify, indentSize, attributeNamePrefix });
           assert.strictEqual(actual, expected);
         });
       }
@@ -120,6 +124,15 @@ suite('Converter Test Suite', () => {
     { to: 'xml', minify: true, expected: fixtures.object.xml.minified, description: 'YAML minified to XML (minified)' },
     { to: 'yaml', minify: false, expected: fixtures.object.yaml.pretty, description: 'YAML minified to YAML (pretty)' },
     { to: 'yaml', minify: true, expected: fixtures.object.yaml.minified, description: 'YAML minified to YAML (minified)' },
+  ]);
+
+  createTestSuite('JSON input with indentSize 4', fixtures.object.json.pretty, [
+    { to: 'json', minify: false, indentSize: 4, expected: fixtures.object.json['4-space'], description: 'JSON to JSON (4-space)' },
+    { to: 'json', minify: true, indentSize: 4, expected: fixtures.object.json.minified, description: 'JSON to JSON (minified)' },
+    { to: 'xml', minify: false, indentSize: 4, expected: fixtures.object.xml['4-space'], description: 'JSON to XML (4-space)' },
+    { to: 'xml', minify: true, indentSize: 4, expected: fixtures.object.xml.minified, description: 'JSON to XML (minified)' },
+    { to: 'yaml', minify: false, indentSize: 4, expected: fixtures.object.yaml['4-space'], description: 'JSON to YAML (4-space)' },
+    { to: 'yaml', minify: true, indentSize: 4, expected: fixtures.object.yaml.minified, description: 'JSON to YAML (minified)' },
   ]);
 
   createTestSuite('XML input with attributeNamePrefix "$"', fixtures.object.xml.pretty, [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `xyjson.indentSize` configuration option to control indentation width (1-8 spaces, default: 2) for XML, YAML, and JSON pretty-print output.

* **Documentation**
  * Updated README to document the new indentation size configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->