### PR TITLE
Fix stale selection applied when selection changes during Quick Pick

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,11 +52,14 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
       const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
       await vscode.window.showTextDocument(doc, { preview: false });
     } else {
-      // showQuickPick is async; guard against document state changes while picker was open
+      // showQuickPick is async; guard against document state changes while picker was open.
+      // Selection is only checked when there was an initial selection — a cursor move on a
+      // whole-document format is harmless and should not abort the operation.
       if (
         document.isClosed ||
         vscode.window.activeTextEditor?.document !== document ||
-        document.version !== documentVersion
+        document.version !== documentVersion ||
+        (hasSelection && !editor.selection.isEqual(selection))
       ) {
         vscode.window.showErrorMessage(`${label} failed: document state changed`);
         return;

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -259,6 +259,49 @@ suite('Extension Test Suite', () => {
       }
     });
 
+    test('format command leaves document unchanged when selection changes during Quick Pick', async () => {
+      const content = readFixture('json-minified.json');
+      const editor = await openEditorWithContent(content);
+      const suiteMock = (vscode.window as any).showQuickPick;
+
+      const startPos = editor.document.positionAt(0);
+      const endPos = editor.document.positionAt(content.length);
+      editor.selection = new vscode.Selection(startPos, endPos);
+
+      (vscode.window as any).showQuickPick = async () => {
+        editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+        return { label: 'Pretty' };
+      };
+
+      try {
+        await vscode.commands.executeCommand('xyjson.formatJson');
+        assert.strictEqual(getEditorText(editor), content);
+      } finally {
+        (vscode.window as any).showQuickPick = suiteMock;
+      }
+    });
+
+    test('format command applies to whole document when cursor moves during Quick Pick (no initial selection)', async () => {
+      const content = readFixture('json-minified.json');
+      const editor = await openEditorWithContent(content);
+      const suiteMock = (vscode.window as any).showQuickPick;
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+
+      (vscode.window as any).showQuickPick = async () => {
+        const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+        editor.selection = new vscode.Selection(lastLine.range.end, lastLine.range.end);
+        return { label: 'Pretty' };
+      };
+
+      try {
+        await vscode.commands.executeCommand('xyjson.formatJson');
+        assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
+      } finally {
+        (vscode.window as any).showQuickPick = suiteMock;
+      }
+    });
+
     test('format command leaves document unchanged when document is readonly', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during Quick Pick dialogs—the extension now prevents incorrect edits when the document or selection changes unexpectedly while a dialog is open.

* **Tests**
  * Added integration tests for edge cases during Quick Pick interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->