### PR TITLE
Add xyjson.outputStyle setting to skip the Quick Pick prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Working with API responses, config files, or legacy XML? Convert between formats
   - **XYJson: Format XML**
   - **XYJson: Format YAML**
 - Works on the entire document, or just the selected text if a selection is active
-- Output format (pretty / minified) selected via Quick Pick on each command
+- Output format (pretty / minified) selected via Quick Pick on each command, or fixed via `xyjson.outputStyle` setting
 - Automatic input format detection:
   - Content starting with `<` → parsed as XML
   - Content starting with `{` or `[` → parsed as JSON (falls back to YAML for YAML flow style)
@@ -36,12 +36,15 @@ Working with API responses, config files, or legacy XML? Convert between formats
    - **Pretty** — indented with newlines
    - **Minified** — single line, no whitespace
 
+   > **Tip:** To skip the Quick Pick entirely, set `xyjson.outputStyle` to `"pretty"` or `"minified"` in your settings. This is useful when you always use the same style or want to bind a command to a keyboard shortcut.
+
 ## Settings
 
-| Setting                         | Type    | Default | Description                                                                                        |
-|---------------------------------|---------|---------|----------------------------------------------------------------------------------------------------|
-| `xyjson.indentSize`             | integer | `2`     | Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output. Min: 1, Max: 8. |
-| `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML.                                  |
+| Setting                         | Type    | Default | Description                                                                                                 |
+|---------------------------------|---------|---------|-------------------------------------------------------------------------------------------------------------|
+| `xyjson.outputStyle`            | string  | `ask`   | Output style for all commands. `ask` shows a Quick Pick each time; `pretty` or `minified` skips the prompt. |
+| `xyjson.indentSize`             | integer | `2`     | Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output. Min: 1, Max: 8.          |
+| `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML.                                           |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,12 @@
     },
     "configuration": {
       "properties": {
+        "xyjson.outputStyle": {
+          "type": "string",
+          "enum": ["ask", "pretty", "minified"],
+          "default": "ask",
+          "description": "Output style for convert and format commands. \"ask\" shows a Quick Pick each time; \"pretty\" and \"minified\" skip the prompt."
+        },
         "xyjson.indentSize": {
           "type": "integer",
           "default": 2,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,24 +26,33 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
     return;
   }
 
-  const pick = await vscode.window.showQuickPick(
-    [
-      { label: 'Pretty', description: 'indented with newlines' },
-      { label: 'Minified', description: 'single line, no whitespace' },
-    ],
-    {
-      placeHolder: 'Select output format',
-      title: action === 'format' ? `Format ${to.toUpperCase()}` : `Convert to ${to.toUpperCase()}`,
-    },
-  );
-  if (pick === undefined) {
-    return;
-  }
-  const minify = pick.label === 'Minified';
-
   const config = vscode.workspace.getConfiguration('xyjson');
+  const outputStyle = config.get<string>('outputStyle', 'ask');
   const indentSize = config.get<number>('indentSize', 2);
   const attributeNamePrefix = config.get<string>('xmlAttributeNamePrefix', '@_');
+
+  let minify: boolean;
+  if (outputStyle === 'minified') {
+    minify = true;
+  } else if (outputStyle === 'pretty') {
+    minify = false;
+  } else {
+    const pick = await vscode.window.showQuickPick(
+      [
+        { label: 'Pretty', description: 'indented with newlines' },
+        { label: 'Minified', description: 'single line, no whitespace' },
+      ],
+      {
+        placeHolder: 'Select output format',
+        title:
+          action === 'format' ? `Format ${to.toUpperCase()}` : `Convert to ${to.toUpperCase()}`,
+      },
+    );
+    if (pick === undefined) {
+      return;
+    }
+    minify = pick.label === 'Minified';
+  }
 
   try {
     const result = convert(content, to, { minify, indentSize, attributeNamePrefix });

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -33,6 +33,12 @@ suite('Extension Test Suite', () => {
 
   const getActiveEditorText = (): string => getEditorText(vscode.window.activeTextEditor!);
 
+  const setOutputStyle = async (value: string): Promise<void> => {
+    await vscode.workspace
+      .getConfiguration('xyjson')
+      .update('outputStyle', value, vscode.ConfigurationTarget.Global);
+  };
+
   const setIndentSize = async (value: number): Promise<void> => {
     await vscode.workspace
       .getConfiguration('xyjson')
@@ -50,6 +56,7 @@ suite('Extension Test Suite', () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     await setIndentSize(2);
     await setAttributeNamePrefix('@_');
+    await setOutputStyle('ask');
   });
 
   suite('Successful Conversion', () => {
@@ -116,6 +123,32 @@ suite('Extension Test Suite', () => {
       const editor = await openEditorWithContent(content);
       await vscode.commands.executeCommand('xyjson.toYaml');
       assert.strictEqual(getEditorText(editor), content);
+    });
+  });
+
+  suite('OutputStyle Configuration', () => {
+    test('skips Quick Pick and produces pretty output when outputStyle is "pretty"', async () => {
+      await setOutputStyle('pretty');
+      quickPickResponse = undefined;
+      await openEditorWithContent(readFixture('json-pretty.json'));
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
+    });
+
+    test('skips Quick Pick and produces minified output when outputStyle is "minified"', async () => {
+      await setOutputStyle('minified');
+      quickPickResponse = undefined;
+      await openEditorWithContent(readFixture('json-pretty.json'));
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-minified.yaml'));
+    });
+
+    test('shows Quick Pick when outputStyle is "ask"', async () => {
+      await setOutputStyle('ask');
+      quickPickResponse = { label: 'Minified' };
+      await openEditorWithContent(readFixture('json-pretty.json'));
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-minified.yaml'));
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `outputStyle` configuration setting allowing users to set a default output format (ask, pretty, or minified) and skip the format selection prompt when configured.

* **Documentation**
  * Updated README with details about the new output style configuration setting and instructions for using it to bypass the format selection dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->