### PR TITLE
Add xyjson.convertOutput setting to control convert result placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Working with API responses, config files, or legacy XML? Convert between formats
 
 ## Settings
 
-| Setting                         | Type    | Default | Description                                                                                                 |
-|---------------------------------|---------|---------|-------------------------------------------------------------------------------------------------------------|
-| `xyjson.outputStyle`            | string  | `ask`   | Output style for all commands. `ask` shows a Quick Pick each time; `pretty` or `minified` skips the prompt. |
-| `xyjson.indentSize`             | integer | `2`     | Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output. Min: 1, Max: 8.          |
-| `xyjson.xmlAttributeNamePrefix` | string  | `@_`    | Prefix added to XML attribute names when parsing or building XML.                                           |
+| Setting                         | Type    | Default  | Description                                                                                                          |
+|---------------------------------|---------|----------|----------------------------------------------------------------------------------------------------------------------|
+| `xyjson.outputStyle`            | string  | `ask`    | Output style for all commands. `ask` shows a Quick Pick each time; `pretty` or `minified` skips the prompt.          |
+| `xyjson.convertOutput`          | string  | `newTab` | Where to display the result of convert commands. `newTab` opens a new tab; `beside` opens beside the current editor. |
+| `xyjson.indentSize`             | integer | `2`      | Number of spaces used for indentation when pretty-formatting XML/YAML/JSON output. Min: 1, Max: 8.                   |
+| `xyjson.xmlAttributeNamePrefix` | string  | `@_`     | Prefix added to XML attribute names when parsing or building XML.                                                    |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -140,6 +140,16 @@
           "default": "ask",
           "description": "Output style used by convert and format commands."
         },
+        "xyjson.convertOutput": {
+          "type": "string",
+          "enum": ["newTab", "beside"],
+          "enumDescriptions": [
+            "Open the converted result in a new tab.",
+            "Open the converted result beside the current editor."
+          ],
+          "default": "newTab",
+          "description": "Where to display the result of convert commands."
+        },
         "xyjson.indentSize": {
           "type": "integer",
           "default": 2,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,13 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
     const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
 
     if (action === 'convert') {
+      const convertOutput = config.get<string>('convertOutput', 'newTab');
       const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
-      await vscode.window.showTextDocument(doc, { preview: false });
+      const showOptions: vscode.TextDocumentShowOptions = { preview: false };
+      if (convertOutput === 'beside') {
+        showOptions.viewColumn = vscode.ViewColumn.Beside;
+      }
+      await vscode.window.showTextDocument(doc, showOptions);
     } else {
       // showQuickPick is async; guard against document state changes while picker was open.
       // Selection is only checked when there was an initial selection — a cursor move on a

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -39,6 +39,12 @@ suite('Extension Test Suite', () => {
       .update('outputStyle', value, vscode.ConfigurationTarget.Global);
   };
 
+  const setConvertOutput = async (value: string): Promise<void> => {
+    await vscode.workspace
+      .getConfiguration('xyjson')
+      .update('convertOutput', value, vscode.ConfigurationTarget.Global);
+  };
+
   const setIndentSize = async (value: number): Promise<void> => {
     await vscode.workspace
       .getConfiguration('xyjson')
@@ -54,9 +60,10 @@ suite('Extension Test Suite', () => {
   teardown(async () => {
     quickPickResponse = { label: 'Pretty' };
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    await setOutputStyle('ask');
+    await setConvertOutput('newTab');
     await setIndentSize(2);
     await setAttributeNamePrefix('@_');
-    await setOutputStyle('ask');
   });
 
   suite('Successful Conversion', () => {
@@ -149,6 +156,24 @@ suite('Extension Test Suite', () => {
       await openEditorWithContent(readFixture('json-pretty.json'));
       await vscode.commands.executeCommand('xyjson.toYaml');
       assert.strictEqual(getActiveEditorText(), readFixture('yaml-minified.yaml'));
+    });
+  });
+
+  suite('ConvertOutput Configuration', () => {
+    test('opens result in new tab, leaving original unchanged when convertOutput is "newTab"', async () => {
+      await setConvertOutput('newTab');
+      const editor = await openEditorWithContent(readFixture('json-pretty.json'));
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
+      assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
+    });
+
+    test('opens result beside current editor, leaving original unchanged when convertOutput is "beside"', async () => {
+      await setConvertOutput('beside');
+      const editor = await openEditorWithContent(readFixture('json-pretty.json'));
+      await vscode.commands.executeCommand('xyjson.toYaml');
+      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
+      assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control where conversion results appear: in a new tab (default) or beside the current editor.

* **Documentation**
  * Updated settings documentation to include the new conversion output configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->