### PR TITLE
Add clipboard paste commands (Paste Clipboard as JSON/XML/YAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Working with API responses, config files, or legacy XML? Convert between formats and pretty-print or minify your data in seconds — without leaving VS Code.
 
 - **Convert** XML ↔ YAML ↔ JSON, or format (pretty-print / minify) in place
+- **Paste from clipboard** — convert clipboard content directly, no need to open a file first
 - Works on a selection or the entire document
 - Automatic input format detection — no need to specify the source format
 - Available from Command Palette and editor right-click menu
@@ -13,6 +14,10 @@ Working with API responses, config files, or legacy XML? Convert between formats
   - **XYJson: Convert to JSON** — from XML or YAML
   - **XYJson: Convert to XML** — from JSON or YAML
   - **XYJson: Convert to YAML** — from JSON or XML
+- Clipboard commands — read from clipboard and open the result in a new tab:
+  - **XYJson: Paste Clipboard as JSON**
+  - **XYJson: Paste Clipboard as XML**
+  - **XYJson: Paste Clipboard as YAML**
 - Format commands — reformat the current document in place:
   - **XYJson: Format JSON**
   - **XYJson: Format XML**
@@ -26,6 +31,8 @@ Working with API responses, config files, or legacy XML? Convert between formats
 
 ## Usage
 
+### Convert an open file
+
 1. Open an XML, JSON, or YAML file
 2. Optionally, select a portion of text to convert only that range
 3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) or right-click in the editor
@@ -37,6 +44,13 @@ Working with API responses, config files, or legacy XML? Convert between formats
    - **Minified** — single line, no whitespace
 
    > **Tip:** To skip the Quick Pick entirely, set `xyjson.outputStyle` to `"pretty"` or `"minified"` in your settings. This is useful when you always use the same style or want to bind a command to a keyboard shortcut.
+
+### Paste from clipboard
+
+1. Copy any XML, JSON, or YAML content to your clipboard
+2. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+3. Run **XYJson: Paste Clipboard as JSON / XML / YAML**
+4. The converted result opens in a new tab — no need to open a file first
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,18 @@
       {
         "command": "xyjson.formatYaml",
         "title": "XYJson: Format YAML"
+      },
+      {
+        "command": "xyjson.clipboardToJson",
+        "title": "XYJson: Paste Clipboard as JSON"
+      },
+      {
+        "command": "xyjson.clipboardToXml",
+        "title": "XYJson: Paste Clipboard as XML"
+      },
+      {
+        "command": "xyjson.clipboardToYaml",
+        "title": "XYJson: Paste Clipboard as YAML"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,6 +105,59 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
   }
 }
 
+async function convertFromClipboard(to: SupportedFormat): Promise<void> {
+  const content = (await vscode.env.clipboard.readText()).trim();
+  if (!content) {
+    vscode.window.showErrorMessage('Conversion failed: Clipboard is empty');
+    return;
+  }
+
+  const config = vscode.workspace.getConfiguration('xyjson');
+  const outputStyle = config.get<'ask' | 'pretty' | 'minified'>('outputStyle', 'ask');
+  const indentSize = config.get<number>('indentSize', 2);
+  const attributeNamePrefix = config.get<string>('xmlAttributeNamePrefix', '@_');
+
+  let minify: boolean;
+  if (outputStyle === 'minified') {
+    minify = true;
+  } else if (outputStyle === 'pretty') {
+    minify = false;
+  } else {
+    const pick = await vscode.window.showQuickPick(
+      [
+        { label: 'Pretty', description: 'indented with newlines' },
+        { label: 'Minified', description: 'single line, no whitespace' },
+      ],
+      {
+        placeHolder: 'Select output format',
+        title: `Paste Clipboard as ${to.toUpperCase()}`,
+      },
+    );
+    if (pick === undefined) {
+      return;
+    }
+    minify = pick.label === 'Minified';
+  }
+
+  try {
+    const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
+    const convertOutput = config.get<'newTab' | 'beside'>('convertOutput', 'newTab');
+    const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
+    const showOptions: vscode.TextDocumentShowOptions = { preview: false };
+    if (convertOutput === 'beside') {
+      showOptions.viewColumn = vscode.ViewColumn.Beside;
+    }
+    await vscode.window.showTextDocument(doc, showOptions);
+    vscode.window.showInformationMessage(
+      `Pasted clipboard as ${to} (${minify ? 'minified' : 'pretty'})`,
+    );
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Conversion failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('xyjson.toJson', () => convertAndReplace('json', 'convert')),
@@ -113,6 +166,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('xyjson.formatJson', () => convertAndReplace('json', 'format')),
     vscode.commands.registerCommand('xyjson.formatXml', () => convertAndReplace('xml', 'format')),
     vscode.commands.registerCommand('xyjson.formatYaml', () => convertAndReplace('yaml', 'format')),
+    vscode.commands.registerCommand('xyjson.clipboardToJson', () => convertFromClipboard('json')),
+    vscode.commands.registerCommand('xyjson.clipboardToXml', () => convertFromClipboard('xml')),
+    vscode.commands.registerCommand('xyjson.clipboardToYaml', () => convertFromClipboard('yaml')),
   );
 }
 

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -333,6 +333,52 @@ suite('Extension Test Suite', () => {
     });
   });
 
+  suite('Clipboard Paste Commands', () => {
+    const cases = [
+      { command: 'xyjson.clipboardToJson', expectedFixture: 'json-pretty.json' },
+      { command: 'xyjson.clipboardToXml', expectedFixture: 'xml-pretty.xml' },
+      { command: 'xyjson.clipboardToYaml', expectedFixture: 'yaml-pretty.yaml' },
+    ] as const;
+
+    const inputFixtures = ['json-pretty.json', 'xml-pretty.xml', 'yaml-pretty.yaml'] as const;
+
+    for (const c of cases) {
+      suite(`${commandLabel(c.command)} command`, () => {
+        for (const inputFixture of inputFixtures) {
+          test(`pastes ${formatOfFixture(inputFixture)} from clipboard as ${formatOfFixture(c.expectedFixture)}`, async () => {
+            await vscode.env.clipboard.writeText(readFixture(inputFixture));
+            await vscode.commands.executeCommand(c.command);
+            assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
+          });
+        }
+
+        test('minified output when "Minified" is selected', async () => {
+          quickPickResponse = { label: 'Minified' };
+          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
+          const expectedFixture = c.expectedFixture.replace('-pretty.', '-minified.');
+          await vscode.commands.executeCommand(c.command);
+          assert.strictEqual(getActiveEditorText(), readFixture(expectedFixture));
+        });
+
+        test('cancelling Quick Pick — command resolves without throwing', async () => {
+          quickPickResponse = undefined;
+          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+
+        test('empty clipboard — command resolves without throwing', async () => {
+          await vscode.env.clipboard.writeText('');
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+
+        test('invalid content — command resolves without throwing', async () => {
+          await vscode.env.clipboard.writeText('not valid json or xml or yaml: {{{');
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+      });
+    }
+  });
+
   suite('Error Cases', () => {
     const commands = ['xyjson.toJson', 'xyjson.toXml', 'xyjson.toYaml'] as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard-to-JSON, clipboard-to-XML, and clipboard-to-YAML conversion commands accessible via Command Palette
  * Results open in new tabs with option to choose pretty or minified output format

* **Documentation**
  * Updated documentation with clipboard conversion usage instructions and step-by-step guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->