### PR TITLE
Add clipboard paste commands (Paste Clipboard as JSON/XML/YAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Working with API responses, config files, or legacy XML? Convert between formats and pretty-print or minify your data in seconds — without leaving VS Code.
 
 - **Convert** XML ↔ YAML ↔ JSON, or format (pretty-print / minify) in place
+- **Paste from clipboard** — convert clipboard content directly, no need to open a file first
 - Works on a selection or the entire document
 - Automatic input format detection — no need to specify the source format
 - Available from Command Palette and editor right-click menu
@@ -17,6 +18,10 @@ Working with API responses, config files, or legacy XML? Convert between formats
   - **XYJson: Format JSON**
   - **XYJson: Format XML**
   - **XYJson: Format YAML**
+- Clipboard commands — read from clipboard and open the result in a new tab or beside the current editor:
+  - **XYJson: Paste Clipboard as JSON**
+  - **XYJson: Paste Clipboard as XML**
+  - **XYJson: Paste Clipboard as YAML**
 - Works on the entire document, or just the selected text if a selection is active
 - Output format (pretty / minified) selected via Quick Pick on each command, or fixed via `xyjson.outputStyle` setting
 - Automatic input format detection:
@@ -25,6 +30,8 @@ Working with API responses, config files, or legacy XML? Convert between formats
   - Everything else → parsed as YAML
 
 ## Usage
+
+### Convert an open file
 
 1. Open an XML, JSON, or YAML file
 2. Optionally, select a portion of text to convert only that range
@@ -37,6 +44,13 @@ Working with API responses, config files, or legacy XML? Convert between formats
    - **Minified** — single line, no whitespace
 
    > **Tip:** To skip the Quick Pick entirely, set `xyjson.outputStyle` to `"pretty"` or `"minified"` in your settings. This is useful when you always use the same style or want to bind a command to a keyboard shortcut.
+
+### Paste from clipboard
+
+1. Copy any XML, JSON, or YAML content to your clipboard
+2. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+3. Run **XYJson: Paste Clipboard as JSON / XML / YAML**
+4. The converted result opens in a new tab or beside the current editor — no need to open a file first
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,18 @@
       {
         "command": "xyjson.formatYaml",
         "title": "XYJson: Format YAML"
+      },
+      {
+        "command": "xyjson.clipboardToJson",
+        "title": "XYJson: Paste Clipboard as JSON"
+      },
+      {
+        "command": "xyjson.clipboardToXml",
+        "title": "XYJson: Paste Clipboard as XML"
+      },
+      {
+        "command": "xyjson.clipboardToYaml",
+        "title": "XYJson: Paste Clipboard as YAML"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,49 @@ import { convert } from './converter';
 
 type Action = 'convert' | 'format';
 
+function readConfig(resource?: vscode.Uri) {
+  const config = vscode.workspace.getConfiguration('xyjson', resource);
+  return {
+    outputStyle: config.get<'ask' | 'pretty' | 'minified'>('outputStyle', 'ask'),
+    convertOutput: config.get<'newTab' | 'beside'>('convertOutput', 'newTab'),
+    indentSize: config.get<number>('indentSize', 2),
+    attributeNamePrefix: config.get<string>('xmlAttributeNamePrefix', '@_'),
+  };
+}
+
+async function resolveMinify(
+  outputStyle: 'ask' | 'pretty' | 'minified',
+  title: string,
+): Promise<boolean | undefined> {
+  if (outputStyle === 'minified') {
+    return true;
+  }
+  if (outputStyle === 'pretty') {
+    return false;
+  }
+  const pick = await vscode.window.showQuickPick(
+    [
+      { label: 'Pretty', description: 'indented with newlines' },
+      { label: 'Minified', description: 'single line, no whitespace' },
+    ],
+    { placeHolder: 'Select output format', title },
+  );
+  return pick === undefined ? undefined : pick.label === 'Minified';
+}
+
+async function openConvertedDocument(
+  content: string,
+  language: SupportedFormat,
+  convertOutput: 'newTab' | 'beside',
+): Promise<void> {
+  const doc = await vscode.workspace.openTextDocument({ content, language });
+  const showOptions: vscode.TextDocumentShowOptions = { preview: false };
+  if (convertOutput === 'beside') {
+    showOptions.viewColumn = vscode.ViewColumn.Beside;
+  }
+  await vscode.window.showTextDocument(doc, showOptions);
+}
+
 async function convertAndReplace(to: SupportedFormat, action: Action): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   const label = action === 'format' ? 'Formatting' : 'Conversion';
@@ -26,45 +69,20 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
     return;
   }
 
-  const config = vscode.workspace.getConfiguration('xyjson', document.uri);
-  const outputStyle = config.get<'ask' | 'pretty' | 'minified'>('outputStyle', 'ask');
-  const indentSize = config.get<number>('indentSize', 2);
-  const attributeNamePrefix = config.get<string>('xmlAttributeNamePrefix', '@_');
+  const { outputStyle, convertOutput, indentSize, attributeNamePrefix } = readConfig(document.uri);
+  const title =
+    action === 'format' ? `Format ${to.toUpperCase()}` : `Convert to ${to.toUpperCase()}`;
 
-  let minify: boolean;
-  if (outputStyle === 'minified') {
-    minify = true;
-  } else if (outputStyle === 'pretty') {
-    minify = false;
-  } else {
-    const pick = await vscode.window.showQuickPick(
-      [
-        { label: 'Pretty', description: 'indented with newlines' },
-        { label: 'Minified', description: 'single line, no whitespace' },
-      ],
-      {
-        placeHolder: 'Select output format',
-        title:
-          action === 'format' ? `Format ${to.toUpperCase()}` : `Convert to ${to.toUpperCase()}`,
-      },
-    );
-    if (pick === undefined) {
-      return;
-    }
-    minify = pick.label === 'Minified';
+  const minify = await resolveMinify(outputStyle, title);
+  if (minify === undefined) {
+    return;
   }
 
   try {
     const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
 
     if (action === 'convert') {
-      const convertOutput = config.get<'newTab' | 'beside'>('convertOutput', 'newTab');
-      const doc = await vscode.workspace.openTextDocument({ content: result, language: to });
-      const showOptions: vscode.TextDocumentShowOptions = { preview: false };
-      if (convertOutput === 'beside') {
-        showOptions.viewColumn = vscode.ViewColumn.Beside;
-      }
-      await vscode.window.showTextDocument(doc, showOptions);
+      await openConvertedDocument(result, to, convertOutput);
     } else {
       // showQuickPick is async; guard against document state changes while picker was open.
       // Selection is only checked when there was an initial selection — a cursor move on a
@@ -105,6 +123,35 @@ async function convertAndReplace(to: SupportedFormat, action: Action): Promise<v
   }
 }
 
+async function convertFromClipboard(to: SupportedFormat): Promise<void> {
+  const content = (await vscode.env.clipboard.readText()).trim();
+  if (!content) {
+    vscode.window.showErrorMessage('Conversion failed: Clipboard is empty');
+    return;
+  }
+
+  const { outputStyle, convertOutput, indentSize, attributeNamePrefix } = readConfig(
+    vscode.window.activeTextEditor?.document.uri,
+  );
+
+  const minify = await resolveMinify(outputStyle, `Paste Clipboard as ${to.toUpperCase()}`);
+  if (minify === undefined) {
+    return;
+  }
+
+  try {
+    const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
+    await openConvertedDocument(result, to, convertOutput);
+    vscode.window.showInformationMessage(
+      `Pasted clipboard as ${to} (${minify ? 'minified' : 'pretty'})`,
+    );
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `Conversion failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('xyjson.toJson', () => convertAndReplace('json', 'convert')),
@@ -113,6 +160,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('xyjson.formatJson', () => convertAndReplace('json', 'format')),
     vscode.commands.registerCommand('xyjson.formatXml', () => convertAndReplace('xml', 'format')),
     vscode.commands.registerCommand('xyjson.formatYaml', () => convertAndReplace('yaml', 'format')),
+    vscode.commands.registerCommand('xyjson.clipboardToJson', () => convertFromClipboard('json')),
+    vscode.commands.registerCommand('xyjson.clipboardToXml', () => convertFromClipboard('xml')),
+    vscode.commands.registerCommand('xyjson.clipboardToYaml', () => convertFromClipboard('yaml')),
   );
 }
 

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -333,6 +333,58 @@ suite('Extension Test Suite', () => {
     });
   });
 
+  suite('Clipboard Paste Commands', () => {
+    const cases = [
+      { command: 'xyjson.clipboardToJson', expectedFixture: 'json-pretty.json' },
+      { command: 'xyjson.clipboardToXml', expectedFixture: 'xml-pretty.xml' },
+      { command: 'xyjson.clipboardToYaml', expectedFixture: 'yaml-pretty.yaml' },
+    ] as const;
+
+    const inputFixtures = ['json-pretty.json', 'xml-pretty.xml', 'yaml-pretty.yaml'] as const;
+
+    for (const c of cases) {
+      suite(`${commandLabel(c.command)} command`, () => {
+        for (const inputFixture of inputFixtures) {
+          test(`pastes ${formatOfFixture(inputFixture)} from clipboard as ${formatOfFixture(c.expectedFixture)}`, async () => {
+            await vscode.env.clipboard.writeText(readFixture(inputFixture));
+            await vscode.commands.executeCommand(c.command);
+            assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
+          });
+        }
+
+        test('minified output when "Minified" is selected', async () => {
+          quickPickResponse = { label: 'Minified' };
+          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
+          const expectedFixture = c.expectedFixture.replace('-pretty.', '-minified.');
+          await vscode.commands.executeCommand(c.command);
+          assert.strictEqual(getActiveEditorText(), readFixture(expectedFixture));
+        });
+
+        test('no active editor — command resolves without throwing', async () => {
+          await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+
+        test('cancelling Quick Pick — command resolves without throwing', async () => {
+          quickPickResponse = undefined;
+          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+
+        test('empty clipboard — command resolves without throwing', async () => {
+          await vscode.env.clipboard.writeText('');
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+
+        test('invalid content — command resolves without throwing', async () => {
+          await vscode.env.clipboard.writeText('not valid json or xml or yaml: {{{');
+          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
+        });
+      });
+    }
+  });
+
   suite('Error Cases', () => {
     const commands = ['xyjson.toJson', 'xyjson.toXml', 'xyjson.toYaml'] as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new clipboard conversion commands to paste and convert clipboard content directly into JSON, XML, or YAML formats.

* **Documentation**
  * Updated README with step-by-step instructions for clipboard conversion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->