### PR TITLE
Add post-edit linting hook to auto-fix TypeScript files with ESLint

### DIFF
--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -20,15 +20,19 @@ process.stdin.on('end', () => {
   }
 
   const projectDir = path.resolve(__dirname, '..', '..');
-  const srcDir = path.join(projectDir, 'src') + path.sep;
-  if (!path.resolve(filePath).startsWith(srcDir)) {
+  const srcDir = path.join(projectDir, 'src');
+  const resolvedFilePath = path.resolve(projectDir, filePath);
+  const relative = path.relative(srcDir, resolvedFilePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
     process.exit(0);
   }
 
   try {
-    execFileSync('npx', ['eslint', '--fix', filePath], {
+    const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+    execFileSync(npxCmd, ['eslint', '--fix', resolvedFilePath], {
       cwd: projectDir,
       stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
     });
   } catch (err) {
     const out = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -43,7 +43,7 @@ process.stdin.on('end', () => {
     });
   } catch (err) {
     const out = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
-    process.stderr.write(out || `eslint failed: ${err.message}`);
-    process.exit(2);
+    process.stderr.write((out || `eslint failed: ${err.message}`) + '\n');
+    process.exitCode = 2;
   }
 });

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -6,6 +6,7 @@
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 
+process.stdin.setEncoding('utf8');
 let input = '';
 process.stdin.on('data', (chunk) => (input += chunk));
 process.stdin.on('end', () => {

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -28,7 +28,7 @@ process.stdin.on('end', () => {
   }
 
   try {
-    const eslintCli = path.join(projectDir, 'node_modules', 'eslint', 'bin', 'eslint.js');
+    const eslintCli = path.join(path.dirname(require.resolve('eslint/package.json')), 'bin', 'eslint.js');
     execFileSync(process.execPath, [eslintCli, '--fix', resolvedFilePath], {
       cwd: projectDir,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -27,8 +27,14 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
+  let eslintCli;
   try {
-    const eslintCli = path.join(path.dirname(require.resolve('eslint/package.json')), 'bin', 'eslint.js');
+    eslintCli = path.join(path.dirname(require.resolve('eslint/package.json')), 'bin', 'eslint.js');
+  } catch {
+    process.exit(0);
+  }
+
+  try {
     execFileSync(process.execPath, [eslintCli, '--fix', resolvedFilePath], {
       cwd: projectDir,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// PostToolUse hook (Edit|Write): auto-fix the edited file with ESLint.
+// Exits 2 with the remaining problems on stderr so Claude sees them.
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+let input = '';
+process.stdin.on('data', (chunk) => (input += chunk));
+process.stdin.on('end', () => {
+  let filePath;
+  try {
+    filePath = JSON.parse(input).tool_input?.file_path;
+  } catch {
+    process.exit(0);
+  }
+  if (typeof filePath !== 'string' || !filePath.endsWith('.ts')) {
+    process.exit(0);
+  }
+
+  const projectDir = path.resolve(__dirname, '..', '..');
+  const srcDir = path.join(projectDir, 'src') + path.sep;
+  if (!path.resolve(filePath).startsWith(srcDir)) {
+    process.exit(0);
+  }
+
+  try {
+    execFileSync('npx', ['eslint', '--fix', filePath], {
+      cwd: projectDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const out = [err.stdout, err.stderr].filter(Boolean).join('\n').trim();
+    process.stderr.write(out || `eslint failed: ${err.message}`);
+    process.exit(2);
+  }
+});

--- a/.claude/hooks/post-edit-lint.js
+++ b/.claude/hooks/post-edit-lint.js
@@ -28,8 +28,8 @@ process.stdin.on('end', () => {
   }
 
   try {
-    const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    execFileSync(npxCmd, ['eslint', '--fix', resolvedFilePath], {
+    const eslintCli = path.join(projectDir, 'node_modules', 'eslint', 'bin', 'eslint.js');
+    execFileSync(process.execPath, [eslintCli, '--fix', resolvedFilePath], {
       cwd: projectDir,
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,7 +45,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-lint.js\"",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/post-edit-lint.js"],
             "timeout": 60
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,18 @@
   },
   "enableAllProjectMcpServers": false,
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-lint.js\"",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated post-edit hook that runs linting fixes after editing TypeScript files in the project source.
  * Updated the Claude setup to trigger this linting step after edit/write actions, alongside the existing stop behavior.

* **Bug Fixes**
  * Improved error handling so linting failures are reported clearly and non-applicable file changes are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->