### PR TITLE
test: pre-activate extension to fix flaky integration timeout

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,4 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
+	// Give activation and each test headroom over Mocha's 2000ms default, which
+	// flaked on cold CI runners (hooks are timeout-bound too).
+	mocha: { timeout: 20000 },
 });

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -7,7 +7,9 @@ suite('Extension Test Suite', () => {
   let quickPickResponse: { label: string } | undefined = { label: 'Pretty' };
   const originalShowQuickPick = (vscode.window as any).showQuickPick;
 
-  suiteSetup(() => {
+  suiteSetup(async () => {
+    // Pre-activate so the first test doesn't hit activation cost and time out (flaky).
+    await vscode.extensions.getExtension('ryo8000.xyjson')?.activate();
     (vscode.window as any).showQuickPick = async () => quickPickResponse;
   });
 


### PR DESCRIPTION
Activate the extension in suiteSetup so the first test no longer pays the activation cost, which occasionally exceeded mocha's 2000ms timeout on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test setup by activating a dependent extension before tests run.
  * Reduced first-test delays and potential timing-related flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->