### PR TITLE
refactor: extract command logic into extensionCore for unit testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests (Linux)
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run integration tests (Linux)
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:integration
 
-      - name: Run tests (non-Linux)
+      - name: Run integration tests (non-Linux)
         if: runner.os != 'Linux'
         run: npm run test:integration
 

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-	files: 'out/test/**/*.test.js',
+	files: 'out/test/integration/**/*.test.js',
 	// Give activation and each test headroom over Mocha's 2000ms default, which
 	// flaked on cold CI runners (hooks are timeout-bound too).
 	mocha: { timeout: 20000 },

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "copy-fixtures": "node ./scripts/copy-fixtures.js",
     "pretest": "npm run compile-tests && npm run lint && node esbuild.js && npm run copy-fixtures",
-    "test": "mocha --ui tdd 'out/test/unit/**/*.test.js'",
+    "test": "mocha --ui tdd \"out/test/unit/**/*.test.js\"",
     "pretest:integration": "npm run pretest",
     "test:integration": "vscode-test",
     "vscode:package": "vsce package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,51 +1,34 @@
 import * as vscode from 'vscode';
 
 import type { SupportedFormat } from './converter';
-import { convert } from './converter';
-
-type Action = 'convert' | 'format';
-
-interface Config {
-  outputStyle: 'ask' | 'pretty' | 'minified';
-  convertOutput: 'newTab' | 'beside';
-  indentSize: number;
-  attributeNamePrefix: string;
-}
+import type {
+  Action,
+  CommandDependencies,
+  Config,
+  ConvertOutput,
+  FormatTarget,
+  OutputStyle,
+} from './extensionCore';
+import {
+  executeClipboardCommand,
+  executeEditorCommand,
+  isDocumentStateStale,
+} from './extensionCore';
 
 function readConfig(resource?: vscode.Uri): Config {
   const config = vscode.workspace.getConfiguration('xyjson', resource);
   return {
-    outputStyle: config.get<'ask' | 'pretty' | 'minified'>('outputStyle', 'ask'),
-    convertOutput: config.get<'newTab' | 'beside'>('convertOutput', 'newTab'),
+    outputStyle: config.get<OutputStyle>('outputStyle', 'ask'),
+    convertOutput: config.get<ConvertOutput>('convertOutput', 'newTab'),
     indentSize: config.get<number>('indentSize', 2),
     attributeNamePrefix: config.get<string>('xmlAttributeNamePrefix', '@_'),
   };
 }
 
-async function resolveMinify(
-  outputStyle: 'ask' | 'pretty' | 'minified',
-  title: string,
-): Promise<boolean | undefined> {
-  if (outputStyle === 'minified') {
-    return true;
-  }
-  if (outputStyle === 'pretty') {
-    return false;
-  }
-  const pick = await vscode.window.showQuickPick(
-    [
-      { label: 'Pretty', description: 'indented with newlines' },
-      { label: 'Minified', description: 'single line, no whitespace' },
-    ],
-    { placeHolder: 'Select output format', title },
-  );
-  return pick === undefined ? undefined : pick.label === 'Minified';
-}
-
 async function openConvertedDocument(
   content: string,
   language: SupportedFormat,
-  convertOutput: 'newTab' | 'beside',
+  convertOutput: ConvertOutput,
 ): Promise<void> {
   const doc = await vscode.workspace.openTextDocument({ content, language });
   const showOptions: vscode.TextDocumentShowOptions = { preview: false };
@@ -55,107 +38,75 @@ async function openConvertedDocument(
   await vscode.window.showTextDocument(doc, showOptions);
 }
 
-async function convertAndReplace(to: SupportedFormat, action: Action): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  const label = action === 'format' ? 'Formatting' : 'Conversion';
+const dependencies: CommandDependencies = {
+  showQuickPick: async (items, options) => await vscode.window.showQuickPick(items, options),
+  openConvertedDocument,
+  showErrorMessage: (message) => {
+    vscode.window.showErrorMessage(message);
+  },
+  showInformationMessage: (message) => {
+    vscode.window.showInformationMessage(message);
+  },
+};
 
-  if (editor === undefined) {
-    vscode.window.showErrorMessage(`${label} failed: No active editor found`);
-    return;
-  }
-
+function createFormatTarget(editor: vscode.TextEditor): FormatTarget {
   const { document, selection } = editor;
-  const documentVersion = document.version;
+  const initialVersion = document.version;
   const hasSelection = !selection.isEmpty;
 
-  const content = hasSelection ? document.getText(selection).trim() : document.getText().trim();
-
-  if (content === '') {
-    vscode.window.showErrorMessage(`${label} failed: Document is empty`);
-    return;
-  }
-
-  const { outputStyle, convertOutput, indentSize, attributeNamePrefix } = readConfig(document.uri);
-  const title =
-    action === 'format' ? `Format ${to.toUpperCase()}` : `Convert to ${to.toUpperCase()}`;
-
-  const minify = await resolveMinify(outputStyle, title);
-  if (minify === undefined) {
-    return;
-  }
-
-  try {
-    const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
-
-    if (action === 'convert') {
-      await openConvertedDocument(result, to, convertOutput);
-    } else {
-      // showQuickPick is async; guard against document state changes while picker was open.
-      // Selection is only checked when there was an initial selection — a cursor move on a
-      // whole-document format is harmless and should not abort the operation.
-      if (
-        document.isClosed ||
-        vscode.window.activeTextEditor?.document !== document ||
-        document.version !== documentVersion ||
-        (hasSelection && !editor.selection.isEqual(selection))
-      ) {
-        vscode.window.showErrorMessage(`${label} failed: document state changed`);
-        return;
-      }
+  return {
+    isStale: () =>
+      isDocumentStateStale({
+        document,
+        activeDocument: vscode.window.activeTextEditor?.document,
+        initialVersion,
+        initialSelection: selection,
+        currentSelection: editor.selection,
+        hasSelection,
+      }),
+    replace: async (content) => {
       const replaceRange = hasSelection
         ? selection
         : new vscode.Range(
             document.lineAt(0).range.start,
             document.lineAt(document.lineCount - 1).range.end,
           );
-      const applied = await editor.edit((editBuilder) => {
-        editBuilder.replace(replaceRange, result);
+      return await editor.edit((editBuilder) => {
+        editBuilder.replace(replaceRange, content);
       });
-      if (!applied) {
-        vscode.window.showErrorMessage(`${label} failed: Could not apply edits`);
-        return;
-      }
-    }
+    },
+  };
+}
 
-    vscode.window.showInformationMessage(
-      action === 'format'
-        ? `Formatted ${to} (${minify ? 'minified' : 'pretty'})`
-        : `Converted to ${to} (${minify ? 'minified' : 'pretty'})`,
-    );
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+async function convertAndReplace(to: SupportedFormat, action: Action): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (editor === undefined) {
+    const label = action === 'format' ? 'Formatting' : 'Conversion';
+    vscode.window.showErrorMessage(`${label} failed: No active editor found`);
+    return;
   }
+
+  const { document, selection } = editor;
+  const content = selection.isEmpty ? document.getText() : document.getText(selection);
+  const config = readConfig(document.uri);
+
+  await executeEditorCommand(
+    action === 'format'
+      ? { content, to, config, action, formatTarget: createFormatTarget(editor) }
+      : { content, to, config, action },
+    dependencies,
+  );
 }
 
 async function convertFromClipboard(to: SupportedFormat): Promise<void> {
-  const content = (await vscode.env.clipboard.readText()).trim();
-  if (content === '') {
-    vscode.window.showErrorMessage('Conversion failed: Clipboard is empty');
-    return;
-  }
-
-  const { outputStyle, convertOutput, indentSize, attributeNamePrefix } = readConfig(
-    vscode.window.activeTextEditor?.document.uri,
+  await executeClipboardCommand(
+    {
+      content: await vscode.env.clipboard.readText(),
+      to,
+      config: readConfig(vscode.window.activeTextEditor?.document.uri),
+    },
+    dependencies,
   );
-
-  const minify = await resolveMinify(outputStyle, `Paste Clipboard as ${to.toUpperCase()}`);
-  if (minify === undefined) {
-    return;
-  }
-
-  try {
-    const result = convert(content, to, { minify, indentSize, attributeNamePrefix });
-    await openConvertedDocument(result, to, convertOutput);
-    vscode.window.showInformationMessage(
-      `Pasted clipboard as ${to} (${minify ? 'minified' : 'pretty'})`,
-    );
-  } catch (err) {
-    vscode.window.showErrorMessage(
-      `Conversion failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
 }
 
 export function activate(context: vscode.ExtensionContext): void {

--- a/src/extensionCore.ts
+++ b/src/extensionCore.ts
@@ -1,0 +1,215 @@
+/**
+ * vscode-free command flow shared by the handlers in `extension.ts`.
+ *
+ * Keeping the orchestration out of the vscode-dependent module lets it run
+ * under the lightweight `npm test` (mocha) suite instead of the heavy VS Code
+ * integration runner. `extension.ts` stays a thin adapter that reads state from
+ * the vscode API and injects the effects below.
+ */
+
+import type { SupportedFormat } from './converter';
+import { convert } from './converter';
+
+export type Action = 'convert' | 'format';
+export type OutputStyle = 'ask' | 'pretty' | 'minified';
+export type ConvertOutput = 'newTab' | 'beside';
+
+export interface Config {
+  outputStyle: OutputStyle;
+  convertOutput: ConvertOutput;
+  indentSize: number;
+  attributeNamePrefix: string;
+}
+
+export interface QuickPickItem {
+  label: 'Pretty' | 'Minified';
+  description: string;
+}
+
+export type ShowQuickPick = (
+  items: QuickPickItem[],
+  options: { placeHolder: string; title: string },
+) => Promise<QuickPickItem | undefined>;
+
+export interface CommandDependencies {
+  showQuickPick: ShowQuickPick;
+  openConvertedDocument: (
+    content: string,
+    language: SupportedFormat,
+    convertOutput: ConvertOutput,
+  ) => Promise<void>;
+  showErrorMessage: (message: string) => void;
+  showInformationMessage: (message: string) => void;
+}
+
+/**
+ * Decides whether output should be minified.
+ *
+ * Returns `true`/`false` directly for the fixed styles, and only falls back to
+ * the Quick Pick for `'ask'`. Returns `undefined` when the user cancels,
+ * signalling the caller to abort.
+ */
+export async function resolveMinify(
+  outputStyle: OutputStyle,
+  title: string,
+  showQuickPick: ShowQuickPick,
+): Promise<boolean | undefined> {
+  if (outputStyle === 'minified') {
+    return true;
+  }
+  if (outputStyle === 'pretty') {
+    return false;
+  }
+  const pick = await showQuickPick(
+    [
+      { label: 'Pretty', description: 'indented with newlines' },
+      { label: 'Minified', description: 'single line, no whitespace' },
+    ],
+    { placeHolder: 'Select output format', title },
+  );
+  return pick === undefined ? undefined : pick.label === 'Minified';
+}
+
+/**
+ * Detects whether the document/editor state changed while the Quick Pick was
+ * open, which would make applying an in-place edit unsafe.
+ *
+ * The selection is only considered when there was an initial selection — a
+ * cursor move on a whole-document format is harmless and must not abort.
+ *
+ * Generic over the document/selection types so the real vscode objects satisfy
+ * the structural constraints without this module importing vscode.
+ */
+export function isDocumentStateStale<
+  TDocument extends { isClosed: boolean; version: number },
+  TSelection extends { isEqual: (other: TSelection) => boolean },
+>({
+  document,
+  activeDocument,
+  initialVersion,
+  initialSelection,
+  currentSelection,
+  hasSelection,
+}: {
+  document: TDocument;
+  activeDocument: TDocument | undefined;
+  initialVersion: number;
+  initialSelection: TSelection;
+  currentSelection: TSelection;
+  hasSelection: boolean;
+}): boolean {
+  return (
+    document.isClosed ||
+    activeDocument !== document ||
+    document.version !== initialVersion ||
+    (hasSelection && !currentSelection.isEqual(initialSelection))
+  );
+}
+
+export interface FormatTarget {
+  isStale: () => boolean;
+  replace: (content: string) => Promise<boolean>;
+}
+
+export type EditorCommand = {
+  content: string;
+  to: SupportedFormat;
+  config: Config;
+} & ({ action: 'convert' } | { action: 'format'; formatTarget: FormatTarget });
+
+export async function executeEditorCommand(
+  command: EditorCommand,
+  dependencies: CommandDependencies,
+): Promise<void> {
+  const label = command.action === 'format' ? 'Formatting' : 'Conversion';
+
+  const content = command.content.trim();
+  if (content === '') {
+    dependencies.showErrorMessage(`${label} failed: Document is empty`);
+    return;
+  }
+
+  const upperCased = command.to.toUpperCase();
+  const minify = await resolveMinify(
+    command.config.outputStyle,
+    command.action === 'format' ? `Format ${upperCased}` : `Convert to ${upperCased}`,
+    dependencies.showQuickPick,
+  );
+  if (minify === undefined) {
+    return;
+  }
+
+  try {
+    const result = convert(content, command.to, {
+      minify,
+      indentSize: command.config.indentSize,
+      attributeNamePrefix: command.config.attributeNamePrefix,
+    });
+
+    if (command.action === 'convert') {
+      await dependencies.openConvertedDocument(result, command.to, command.config.convertOutput);
+    } else {
+      // showQuickPick is async; guard against document state changes while the picker was open.
+      if (command.formatTarget.isStale()) {
+        dependencies.showErrorMessage(`${label} failed: document state changed`);
+        return;
+      }
+      if (!(await command.formatTarget.replace(result))) {
+        dependencies.showErrorMessage(`${label} failed: Could not apply edits`);
+        return;
+      }
+    }
+
+    dependencies.showInformationMessage(
+      command.action === 'format'
+        ? `Formatted ${command.to} (${minify ? 'minified' : 'pretty'})`
+        : `Converted to ${command.to} (${minify ? 'minified' : 'pretty'})`,
+    );
+  } catch (err) {
+    dependencies.showErrorMessage(
+      `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export interface ClipboardCommand {
+  content: string;
+  to: SupportedFormat;
+  config: Config;
+}
+
+export async function executeClipboardCommand(
+  command: ClipboardCommand,
+  dependencies: CommandDependencies,
+): Promise<void> {
+  const content = command.content.trim();
+  if (content === '') {
+    dependencies.showErrorMessage('Conversion failed: Clipboard is empty');
+    return;
+  }
+
+  const minify = await resolveMinify(
+    command.config.outputStyle,
+    `Paste Clipboard as ${command.to.toUpperCase()}`,
+    dependencies.showQuickPick,
+  );
+  if (minify === undefined) {
+    return;
+  }
+
+  try {
+    const result = convert(content, command.to, {
+      minify,
+      indentSize: command.config.indentSize,
+      attributeNamePrefix: command.config.attributeNamePrefix,
+    });
+    await dependencies.openConvertedDocument(result, command.to, command.config.convertOutput);
+    dependencies.showInformationMessage(
+      `Pasted clipboard as ${command.to} (${minify ? 'minified' : 'pretty'})`,
+    );
+  } catch (err) {
+    dependencies.showErrorMessage(
+      `Conversion failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -3,9 +3,35 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-suite('Extension Test Suite', () => {
+/**
+ * Only behavior that needs a real VS Code host belongs here — command
+ * registration, real editors/selections, the workspace configuration, the
+ * clipboard, and the edit API. The command flow itself (empty input, Quick Pick
+ * cancellation, error and success messages) is covered by the much faster
+ * `src/test/unit/extension.test.ts`.
+ */
+suite('Extension Integration Test Suite', () => {
   let quickPickResponse: { label: string } | undefined = { label: 'Pretty' };
   const originalShowQuickPick = (vscode.window as any).showQuickPick;
+
+  const readFixture = (filename: string): string =>
+    fs.readFileSync(path.join(__dirname, '../fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
+
+  const openEditorWithContent = async (content: string): Promise<vscode.TextEditor> => {
+    const document = await vscode.workspace.openTextDocument({ content, language: 'plaintext' });
+    return await vscode.window.showTextDocument(document);
+  };
+
+  const getEditorText = (editor: vscode.TextEditor): string =>
+    editor.document.getText().replace(/\r\n/g, '\n');
+
+  const getActiveEditorText = (): string => getEditorText(vscode.window.activeTextEditor!);
+
+  const updateConfig = async (key: string, value: string | number): Promise<void> => {
+    await vscode.workspace
+      .getConfiguration('xyjson')
+      .update(key, value, vscode.ConfigurationTarget.Global);
+  };
 
   suiteSetup(async () => {
     // Pre-activate so the first test doesn't hit activation cost and time out (flaky).
@@ -17,249 +43,113 @@ suite('Extension Test Suite', () => {
     (vscode.window as any).showQuickPick = originalShowQuickPick;
   });
 
-  const commandLabel = (command: string): string => command.replace(/^xyjson\./, '');
-
-  const formatOfFixture = (fixture: string): string => path.extname(fixture).slice(1).toUpperCase();
-
-  const readFixture = (filename: string): string =>
-    fs.readFileSync(path.join(__dirname, '../fixtures', filename), 'utf-8').replace(/\r\n/g, '\n');
-
-  const openEditorWithContent = async (content: string): Promise<vscode.TextEditor> => {
-    const doc = await vscode.workspace.openTextDocument({ content, language: 'plaintext' });
-    return await vscode.window.showTextDocument(doc);
-  };
-
-  const getEditorText = (editor: vscode.TextEditor): string => {
-    return editor.document.getText().replace(/\r\n/g, '\n');
-  };
-
-  const getActiveEditorText = (): string => getEditorText(vscode.window.activeTextEditor!);
-
-  const setOutputStyle = async (value: string): Promise<void> => {
-    await vscode.workspace
-      .getConfiguration('xyjson')
-      .update('outputStyle', value, vscode.ConfigurationTarget.Global);
-  };
-
-  const setConvertOutput = async (value: string): Promise<void> => {
-    await vscode.workspace
-      .getConfiguration('xyjson')
-      .update('convertOutput', value, vscode.ConfigurationTarget.Global);
-  };
-
-  const setIndentSize = async (value: number): Promise<void> => {
-    await vscode.workspace
-      .getConfiguration('xyjson')
-      .update('indentSize', value, vscode.ConfigurationTarget.Global);
-  };
-
-  const setAttributeNamePrefix = async (value: string): Promise<void> => {
-    await vscode.workspace
-      .getConfiguration('xyjson')
-      .update('xmlAttributeNamePrefix', value, vscode.ConfigurationTarget.Global);
-  };
-
   teardown(async () => {
     quickPickResponse = { label: 'Pretty' };
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-    await setOutputStyle('ask');
-    await setConvertOutput('newTab');
-    await setIndentSize(2);
-    await setAttributeNamePrefix('@_');
+    await updateConfig('outputStyle', 'ask');
+    await updateConfig('convertOutput', 'newTab');
+    await updateConfig('indentSize', 2);
+    await updateConfig('xmlAttributeNamePrefix', '@_');
   });
 
-  suite('Successful Conversion', () => {
-    const cases = [
-      { command: 'xyjson.toJson', expectedFixture: 'json-pretty.json' },
-      { command: 'xyjson.toXml', expectedFixture: 'xml-pretty.xml' },
-      { command: 'xyjson.toYaml', expectedFixture: 'yaml-pretty.yaml' },
-    ] as const;
-
-    const inputFixtures = ['json-pretty.json', 'xml-pretty.xml', 'yaml-pretty.yaml'] as const;
-
-    for (const c of cases) {
-      suite(`${commandLabel(c.command)} command`, () => {
-        for (const inputFixture of inputFixtures) {
-          test(`converts ${formatOfFixture(inputFixture)} to ${formatOfFixture(c.expectedFixture)}`, async () => {
-            await openEditorWithContent(readFixture(inputFixture));
-            await vscode.commands.executeCommand(c.command);
-            assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
-          });
-        }
-      });
+  test('registers all public commands', async () => {
+    const registeredCommands = await vscode.commands.getCommands(true);
+    const expectedCommands = [
+      'xyjson.toJson',
+      'xyjson.toXml',
+      'xyjson.toYaml',
+      'xyjson.formatJson',
+      'xyjson.formatXml',
+      'xyjson.formatYaml',
+      'xyjson.clipboardToJson',
+      'xyjson.clipboardToXml',
+      'xyjson.clipboardToYaml',
+    ];
+    for (const command of expectedCommands) {
+      assert.ok(registeredCommands.includes(command), `Expected ${command} to be registered`);
     }
   });
 
-  suite('Format Commands', () => {
-    const cases = [
-      { command: 'xyjson.formatJson', input: 'json-minified.json', expectedFixture: 'json-pretty.json' },
-      { command: 'xyjson.formatXml',  input: 'xml-minified.xml',   expectedFixture: 'xml-pretty.xml'  },
-      { command: 'xyjson.formatYaml', input: 'yaml-minified.yaml', expectedFixture: 'yaml-pretty.yaml' },
-    ] as const;
-
-    for (const { command, input, expectedFixture } of cases) {
-      test(`${commandLabel(command)} reformats minified input`, async () => {
-        const editor = await openEditorWithContent(readFixture(input));
-        await vscode.commands.executeCommand(command);
-        assert.strictEqual(getEditorText(editor), readFixture(expectedFixture));
-      });
-    }
+  test('converts XML to JSON in a new editor', async () => {
+    const sourceEditor = await openEditorWithContent(readFixture('xml-pretty.xml'));
+    await vscode.commands.executeCommand('xyjson.toJson');
+    assert.strictEqual(getActiveEditorText(), readFixture('json-pretty.json'));
+    assert.strictEqual(getEditorText(sourceEditor), readFixture('xml-pretty.xml'));
+    assert.strictEqual(vscode.window.activeTextEditor?.document.languageId, 'json');
   });
 
-  suite('Output Format Selection', () => {
-    const cases = [
-      { command: 'xyjson.toJson', expectedFixture: 'json-minified.json' },
-      { command: 'xyjson.toXml', expectedFixture: 'xml-minified.xml' },
-      { command: 'xyjson.toYaml', expectedFixture: 'yaml-minified.yaml' },
-    ] as const;
-
-    for (const c of cases) {
-      test(`${commandLabel(c.command)} produces minified output when "Minified" is selected`, async () => {
-        quickPickResponse = { label: 'Minified' };
-        await openEditorWithContent(readFixture('json-pretty.json'));
-        await vscode.commands.executeCommand(c.command);
-        assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
-      });
-    }
-
-    test('cancelling Quick Pick leaves document unchanged', async () => {
-      quickPickResponse = undefined;
-      const content = readFixture('json-pretty.json');
-      const editor = await openEditorWithContent(content);
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getEditorText(editor), content);
-    });
+  test('formats the current document through the VS Code edit API', async () => {
+    const editor = await openEditorWithContent(readFixture('json-minified.json'));
+    await vscode.commands.executeCommand('xyjson.formatJson');
+    assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
   });
 
-  suite('OutputStyle Configuration', () => {
-    test('skips Quick Pick and produces pretty output when outputStyle is "pretty"', async () => {
-      await setOutputStyle('pretty');
-      quickPickResponse = undefined;
-      await openEditorWithContent(readFixture('json-pretty.json'));
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
-    });
+  test('converts only the selected text', async () => {
+    const json = readFixture('json-pretty.json');
+    const prefix = 'prefix text\n';
+    const suffix = '\nsuffix text';
+    const editor = await openEditorWithContent(prefix + json + suffix);
+    editor.selection = new vscode.Selection(
+      editor.document.positionAt(prefix.length),
+      editor.document.positionAt(prefix.length + json.length),
+    );
 
-    test('skips Quick Pick and produces minified output when outputStyle is "minified"', async () => {
-      await setOutputStyle('minified');
-      quickPickResponse = undefined;
-      await openEditorWithContent(readFixture('json-pretty.json'));
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-minified.yaml'));
-    });
+    await vscode.commands.executeCommand('xyjson.toYaml');
 
-    test('shows Quick Pick when outputStyle is "ask"', async () => {
-      await setOutputStyle('ask');
-      quickPickResponse = { label: 'Minified' };
-      await openEditorWithContent(readFixture('json-pretty.json'));
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-minified.yaml'));
-    });
+    assert.strictEqual(getEditorText(editor), prefix + json + suffix);
+    assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
   });
 
-  suite('ConvertOutput Configuration', () => {
-    test('opens result in new tab, leaving original unchanged when convertOutput is "newTab"', async () => {
-      await setConvertOutput('newTab');
-      const editor = await openEditorWithContent(readFixture('json-pretty.json'));
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
-      assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
-      assert.strictEqual(
-        vscode.window.activeTextEditor?.viewColumn,
-        editor.viewColumn,
-        'Output should be in the same column',
-      );
-    });
+  test('reads output and conversion settings from the workspace configuration', async () => {
+    await updateConfig('outputStyle', 'pretty');
+    await updateConfig('indentSize', 4);
+    await updateConfig('xmlAttributeNamePrefix', '$');
+    quickPickResponse = undefined;
+    await openEditorWithContent(readFixture('xml-pretty.xml'));
 
-    test('opens result beside current editor, leaving original unchanged when convertOutput is "beside"', async () => {
-      await setConvertOutput('beside');
-      const editor = await openEditorWithContent(readFixture('json-pretty.json'));
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
-      assert.strictEqual(getEditorText(editor), readFixture('json-pretty.json'));
-      assert.ok(
-        vscode.window.activeTextEditor !== undefined,
-        'Expected an active editor after conversion',
-      );
-      assert.notStrictEqual(
-        vscode.window.activeTextEditor.viewColumn,
-        editor.viewColumn,
-        'Output should be in a different column',
-      );
-    });
+    await vscode.commands.executeCommand('xyjson.toJson');
+
+    const parsed = JSON.parse(getActiveEditorText());
+    assert.strictEqual(parsed.profiles.$id, '1');
+    assert.ok(getActiveEditorText().includes('    "name": "test"'));
   });
 
-  suite('IndentSize Configuration', () => {
-    const cases = [
-      { command: 'xyjson.toJson', expectedFixture: 'json-4-space.json' },
-      { command: 'xyjson.toYaml', expectedFixture: 'yaml-4-space.yaml' },
-      { command: 'xyjson.toXml', expectedFixture: 'xml-4-space.xml' },
-    ] as const;
-
-    for (const { command, expectedFixture } of cases) {
-      test(`${commandLabel(command)} produces 4-space indented output when xyjson.indentSize is 4`, async () => {
-        await setIndentSize(4);
-        await openEditorWithContent(readFixture('json-pretty.json'));
-        await vscode.commands.executeCommand(command);
-        assert.strictEqual(getActiveEditorText(), readFixture(expectedFixture));
-      });
-    }
+  test('opens converted output beside the source editor', async () => {
+    await updateConfig('convertOutput', 'beside');
+    const sourceEditor = await openEditorWithContent(readFixture('json-pretty.json'));
+    await vscode.commands.executeCommand('xyjson.toYaml');
+    assert.notStrictEqual(vscode.window.activeTextEditor?.viewColumn, sourceEditor.viewColumn);
   });
 
-  suite('AttributeNamePrefix Configuration', () => {
-    const cases = [
-      { prefix: '$', expectedKey: '$id' },
-      { prefix: '', expectedKey: 'id' },
-      { prefix: 'a_', expectedKey: 'a_id' },
-    ] as const;
-
-    for (const { prefix, expectedKey } of cases) {
-      test(`toJson maps attribute key with prefix "${prefix}"`, async () => {
-        await setAttributeNamePrefix(prefix);
-        await openEditorWithContent(readFixture('xml-pretty.xml'));
-        await vscode.commands.executeCommand('xyjson.toJson');
-        const parsed = JSON.parse(getActiveEditorText());
-        assert.strictEqual(parsed.profiles[expectedKey], '1');
-      });
-    }
-
-    test('toXml round-trip preserves attribute with custom prefix "$"', async () => {
-      await setAttributeNamePrefix('$');
-      await openEditorWithContent(readFixture('xml-pretty.xml'));
-      await vscode.commands.executeCommand('xyjson.toXml');
-      const first = getActiveEditorText();
-      await vscode.commands.executeCommand('xyjson.toXml');
-      assert.strictEqual(getActiveEditorText(), first);
-    });
+  test('uses the VS Code clipboard and opens output without an active editor', async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    await vscode.env.clipboard.writeText(readFixture('yaml-pretty.yaml'));
+    await vscode.commands.executeCommand('xyjson.clipboardToXml');
+    assert.strictEqual(getActiveEditorText(), readFixture('xml-pretty.xml'));
   });
 
-  suite('Selection-only Conversion', () => {
-    test('converts only the selected text, leaving the rest unchanged', async () => {
-      const jsonSnippet = readFixture('json-pretty.json');
-      const prefix = 'prefix text\n';
-      const suffix = '\nsuffix text';
-      const editor = await openEditorWithContent(prefix + jsonSnippet + suffix);
-
-      const startPos = editor.document.positionAt(prefix.length);
-      const endPos = editor.document.positionAt(prefix.length + jsonSnippet.length);
-      editor.selection = new vscode.Selection(startPos, endPos);
-
-      await vscode.commands.executeCommand('xyjson.toYaml');
-
-      assert.strictEqual(getEditorText(editor), prefix + jsonSnippet + suffix);
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
-    });
-
-    test('converts entire document when selection is empty', async () => {
-      await openEditorWithContent(readFixture('json-pretty.json'));
-      // selection is empty by default
-      await vscode.commands.executeCommand('xyjson.toYaml');
-      assert.strictEqual(getActiveEditorText(), readFixture('yaml-pretty.yaml'));
-    });
+  test('cancelling Quick Pick leaves the source document unchanged', async () => {
+    quickPickResponse = undefined;
+    const content = readFixture('json-pretty.json');
+    const editor = await openEditorWithContent(content);
+    await vscode.commands.executeCommand('xyjson.toYaml');
+    assert.strictEqual(getEditorText(editor), content);
+    assert.strictEqual(vscode.window.activeTextEditor, editor);
   });
 
+  test('a readonly editor rejects formatting without changing the document', async () => {
+    const content = readFixture('json-minified.json');
+    const editor = await openEditorWithContent(content);
+    await vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');
+    await vscode.commands.executeCommand('xyjson.formatJson');
+    assert.strictEqual(getEditorText(editor), content);
+  });
+
+  // The staleness guard reads live vscode state from inside the Quick Pick
+  // callback, which unit tests cannot exercise — only the predicate itself is
+  // covered there. These tests verify the wiring.
   suite('Format Command Guard Behavior', () => {
-    test('format command leaves document unchanged when active editor changes during Quick Pick', async () => {
+    test('leaves the document unchanged when the active editor changes during Quick Pick', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);
       const suiteMock = (vscode.window as any).showQuickPick;
@@ -277,7 +167,7 @@ suite('Extension Test Suite', () => {
       }
     });
 
-    test('format command leaves document unchanged when document is edited during Quick Pick', async () => {
+    test('leaves the document unchanged when it is edited during Quick Pick', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);
       const suiteMock = (vscode.window as any).showQuickPick;
@@ -300,14 +190,15 @@ suite('Extension Test Suite', () => {
       }
     });
 
-    test('format command leaves document unchanged when selection changes during Quick Pick', async () => {
+    test('leaves the document unchanged when the selection changes during Quick Pick', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);
       const suiteMock = (vscode.window as any).showQuickPick;
 
-      const startPos = editor.document.positionAt(0);
-      const endPos = editor.document.positionAt(content.length);
-      editor.selection = new vscode.Selection(startPos, endPos);
+      editor.selection = new vscode.Selection(
+        editor.document.positionAt(0),
+        editor.document.positionAt(content.length),
+      );
 
       (vscode.window as any).showQuickPick = async () => {
         editor.selection = new vscode.Selection(
@@ -325,7 +216,7 @@ suite('Extension Test Suite', () => {
       }
     });
 
-    test('format command applies to whole document when cursor moves during Quick Pick (no initial selection)', async () => {
+    test('formats the whole document when only the cursor moves during Quick Pick', async () => {
       const content = readFixture('json-minified.json');
       const editor = await openEditorWithContent(content);
       const suiteMock = (vscode.window as any).showQuickPick;
@@ -344,106 +235,6 @@ suite('Extension Test Suite', () => {
       } finally {
         (vscode.window as any).showQuickPick = suiteMock;
       }
-    });
-  });
-
-  suite('Clipboard Paste Commands', () => {
-    const cases = [
-      { command: 'xyjson.clipboardToJson', expectedFixture: 'json-pretty.json' },
-      { command: 'xyjson.clipboardToXml', expectedFixture: 'xml-pretty.xml' },
-      { command: 'xyjson.clipboardToYaml', expectedFixture: 'yaml-pretty.yaml' },
-    ] as const;
-
-    const inputFixtures = ['json-pretty.json', 'xml-pretty.xml', 'yaml-pretty.yaml'] as const;
-
-    for (const c of cases) {
-      suite(`${commandLabel(c.command)} command`, () => {
-        for (const inputFixture of inputFixtures) {
-          test(`pastes ${formatOfFixture(inputFixture)} from clipboard as ${formatOfFixture(c.expectedFixture)}`, async () => {
-            await vscode.env.clipboard.writeText(readFixture(inputFixture));
-            await vscode.commands.executeCommand(c.command);
-            assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
-          });
-        }
-
-        test('minified output when "Minified" is selected', async () => {
-          quickPickResponse = { label: 'Minified' };
-          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
-          const expectedFixture = c.expectedFixture.replace('-pretty.', '-minified.');
-          await vscode.commands.executeCommand(c.command);
-          assert.strictEqual(getActiveEditorText(), readFixture(expectedFixture));
-        });
-
-        test('no active editor — opens result in a new tab', async () => {
-          await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
-          await vscode.commands.executeCommand(c.command);
-          assert.ok(
-            vscode.window.activeTextEditor !== undefined,
-            'Expected a new editor to be opened',
-          );
-          assert.strictEqual(getActiveEditorText(), readFixture(c.expectedFixture));
-        });
-
-        test('cancelling Quick Pick — command resolves without throwing', async () => {
-          quickPickResponse = undefined;
-          await vscode.env.clipboard.writeText(readFixture('json-pretty.json'));
-          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
-        });
-
-        test('empty clipboard — command resolves without throwing', async () => {
-          await vscode.env.clipboard.writeText('');
-          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
-        });
-
-        test('invalid content — command resolves without throwing', async () => {
-          await vscode.env.clipboard.writeText('not valid json or xml or yaml: {{{');
-          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(c.command)));
-        });
-      });
-    }
-  });
-
-  suite('Error Cases', () => {
-    const commands = ['xyjson.toJson', 'xyjson.toXml', 'xyjson.toYaml'] as const;
-
-    for (const command of commands) {
-      suite(`${command} command`, () => {
-        test('no active editor — command resolves without throwing', async () => {
-          await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-          await assert.doesNotReject(Promise.resolve(vscode.commands.executeCommand(command)));
-        });
-
-        test('empty document — document unchanged', async () => {
-          const editor = await openEditorWithContent('');
-          await vscode.commands.executeCommand(command);
-          assert.strictEqual(getEditorText(editor), '');
-        });
-
-        test('whitespace-only document — document unchanged', async () => {
-          const content = '   \n  \n  ';
-          const editor = await openEditorWithContent(content);
-          await vscode.commands.executeCommand(command);
-          assert.strictEqual(getEditorText(editor), content);
-        });
-
-        test('invalid content — document unchanged', async () => {
-          const invalid = 'not valid json or xml or yaml: {{{';
-          const editor = await openEditorWithContent(invalid);
-          await vscode.commands.executeCommand(command);
-          assert.strictEqual(getEditorText(editor), invalid);
-        });
-      });
-    }
-
-    test('format command leaves document unchanged when document is readonly', async () => {
-      const content = readFixture('json-minified.json');
-      const editor = await openEditorWithContent(content);
-      await vscode.commands.executeCommand(
-        'workbench.action.files.setActiveEditorReadonlyInSession',
-      );
-      await vscode.commands.executeCommand('xyjson.formatJson');
-      assert.strictEqual(getEditorText(editor), content);
     });
   });
 });

--- a/src/test/integration/extension.test.ts
+++ b/src/test/integration/extension.test.ts
@@ -128,6 +128,12 @@ suite('Extension Integration Test Suite', () => {
     assert.strictEqual(getActiveEditorText(), readFixture('xml-pretty.xml'));
   });
 
+  test('aborts a format command when no editor is open', async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    await vscode.commands.executeCommand('xyjson.formatJson');
+    assert.strictEqual(vscode.window.activeTextEditor, undefined);
+  });
+
   test('cancelling Quick Pick leaves the source document unchanged', async () => {
     quickPickResponse = undefined;
     const content = readFixture('json-pretty.json');

--- a/src/test/unit/extension.test.ts
+++ b/src/test/unit/extension.test.ts
@@ -1,0 +1,315 @@
+import * as assert from 'assert';
+
+import type { SupportedFormat } from '../../converter';
+import type { CommandDependencies, Config, QuickPickItem } from '../../extensionCore';
+import {
+  executeClipboardCommand,
+  executeEditorCommand,
+  isDocumentStateStale,
+  resolveMinify,
+} from '../../extensionCore';
+
+suite('Extension Core Test Suite', () => {
+  const config: Config = {
+    outputStyle: 'ask',
+    convertOutput: 'newTab',
+    indentSize: 2,
+    attributeNamePrefix: '@_',
+  };
+
+  const createHarness = (
+    overrides: Partial<CommandDependencies> = {},
+  ): {
+    dependencies: CommandDependencies;
+    errors: string[];
+    information: string[];
+    opened: { content: string; language: SupportedFormat; convertOutput: string }[];
+  } => {
+    const errors: string[] = [];
+    const information: string[] = [];
+    const opened: { content: string; language: SupportedFormat; convertOutput: string }[] = [];
+    const dependencies: CommandDependencies = {
+      showQuickPick: async () => ({ label: 'Pretty', description: '' }),
+      openConvertedDocument: async (content, language, convertOutput) => {
+        opened.push({ content, language, convertOutput });
+      },
+      showErrorMessage: (message) => {
+        errors.push(message);
+      },
+      showInformationMessage: (message) => {
+        information.push(message);
+      },
+      ...overrides,
+    };
+    return { dependencies, errors, information, opened };
+  };
+
+  suite('resolveMinify', () => {
+    const failIfPrompted = async (): Promise<QuickPickItem | undefined> => {
+      throw new Error('Quick Pick should not be shown');
+    };
+
+    test('returns true for "minified" without prompting', async () => {
+      assert.strictEqual(await resolveMinify('minified', 'title', failIfPrompted), true);
+    });
+
+    test('returns false for "pretty" without prompting', async () => {
+      assert.strictEqual(await resolveMinify('pretty', 'title', failIfPrompted), false);
+    });
+
+    test('returns the choice made for "ask"', async () => {
+      assert.strictEqual(
+        await resolveMinify('ask', 'title', async () => ({ label: 'Minified', description: '' })),
+        true,
+      );
+      assert.strictEqual(
+        await resolveMinify('ask', 'title', async () => ({ label: 'Pretty', description: '' })),
+        false,
+      );
+    });
+
+    test('returns undefined when the Quick Pick is cancelled', async () => {
+      assert.strictEqual(await resolveMinify('ask', 'title', async () => undefined), undefined);
+    });
+
+    test('passes the choices and title to the Quick Pick', async () => {
+      let labels: string[] = [];
+      let title = '';
+      await resolveMinify('ask', 'Convert to JSON', async (items, options) => {
+        labels = items.map((item) => item.label);
+        title = options.title;
+        return undefined;
+      });
+      assert.deepStrictEqual(labels, ['Pretty', 'Minified']);
+      assert.strictEqual(title, 'Convert to JSON');
+    });
+  });
+
+  suite('isDocumentStateStale', () => {
+    interface FakeDocument {
+      isClosed: boolean;
+      version: number;
+    }
+
+    interface FakeSelection {
+      isEqual: (other: FakeSelection) => boolean;
+    }
+
+    interface StaleArgs {
+      document: FakeDocument;
+      activeDocument: FakeDocument | undefined;
+      initialVersion: number;
+      initialSelection: FakeSelection;
+      currentSelection: FakeSelection;
+      hasSelection: boolean;
+    }
+
+    // Structural stand-in for vscode.Selection: two selections are equal only
+    // when they are the same object, mirroring a selection that never moved.
+    const createSelection = (): FakeSelection => {
+      const self: FakeSelection = { isEqual: (other: FakeSelection): boolean => other === self };
+      return self;
+    };
+
+    const createArgs = (): StaleArgs => {
+      const document = { isClosed: false, version: 1 };
+      const selection = createSelection();
+      return {
+        document,
+        activeDocument: document,
+        initialVersion: 1,
+        initialSelection: selection,
+        currentSelection: selection,
+        hasSelection: true,
+      };
+    };
+
+    test('returns false when the document state is unchanged', () => {
+      assert.strictEqual(isDocumentStateStale(createArgs()), false);
+    });
+
+    test('detects a closed document', () => {
+      const args = createArgs();
+      args.document.isClosed = true;
+      assert.strictEqual(isDocumentStateStale(args), true);
+    });
+
+    test('detects the active editor moving to another document', () => {
+      const args = createArgs();
+      args.activeDocument = undefined;
+      assert.strictEqual(isDocumentStateStale(args), true);
+    });
+
+    test('detects a document version change', () => {
+      const args = createArgs();
+      args.document.version = 2;
+      assert.strictEqual(isDocumentStateStale(args), true);
+    });
+
+    test('detects a selection change when text was initially selected', () => {
+      const args = createArgs();
+      args.currentSelection = createSelection();
+      assert.strictEqual(isDocumentStateStale(args), true);
+    });
+
+    test('allows a cursor move when there was no initial selection', () => {
+      const args = createArgs();
+      args.currentSelection = createSelection();
+      args.hasSelection = false;
+      assert.strictEqual(isDocumentStateStale(args), false);
+    });
+  });
+
+  suite('executeEditorCommand', () => {
+    test('rejects whitespace-only content before prompting', async () => {
+      let prompted = false;
+      const harness = createHarness({
+        showQuickPick: async () => {
+          prompted = true;
+          return undefined;
+        },
+      });
+      await executeEditorCommand(
+        { content: ' \n ', to: 'json', action: 'convert', config },
+        harness.dependencies,
+      );
+      assert.deepStrictEqual(harness.errors, ['Conversion failed: Document is empty']);
+      assert.strictEqual(prompted, false);
+    });
+
+    test('does nothing when the Quick Pick is cancelled', async () => {
+      const harness = createHarness({ showQuickPick: async () => undefined });
+      await executeEditorCommand(
+        { content: '{"a":1}', to: 'yaml', action: 'convert', config },
+        harness.dependencies,
+      );
+      assert.strictEqual(harness.opened.length, 0);
+      assert.strictEqual(harness.information.length, 0);
+    });
+
+    test('trims input and applies the configured style, indent size and output target', async () => {
+      const harness = createHarness();
+      await executeEditorCommand(
+        {
+          content: '  {"a":{"b":1}} \n',
+          to: 'json',
+          action: 'convert',
+          config: { ...config, outputStyle: 'pretty', convertOutput: 'beside', indentSize: 4 },
+        },
+        harness.dependencies,
+      );
+      assert.deepStrictEqual(harness.opened, [
+        {
+          content: '{\n    "a": {\n        "b": 1\n    }\n}\n',
+          language: 'json',
+          convertOutput: 'beside',
+        },
+      ]);
+      assert.deepStrictEqual(harness.information, ['Converted to json (pretty)']);
+    });
+
+    test('does not format when the document state became stale', async () => {
+      let replaced = false;
+      const harness = createHarness();
+      await executeEditorCommand(
+        {
+          content: '{"a":1}',
+          to: 'json',
+          action: 'format',
+          config,
+          formatTarget: {
+            isStale: () => true,
+            replace: async () => {
+              replaced = true;
+              return true;
+            },
+          },
+        },
+        harness.dependencies,
+      );
+      assert.strictEqual(replaced, false);
+      assert.deepStrictEqual(harness.errors, ['Formatting failed: document state changed']);
+    });
+
+    test('reports when a format edit cannot be applied', async () => {
+      const harness = createHarness();
+      await executeEditorCommand(
+        {
+          content: '{"a":1}',
+          to: 'json',
+          action: 'format',
+          config,
+          formatTarget: { isStale: () => false, replace: async () => false },
+        },
+        harness.dependencies,
+      );
+      assert.deepStrictEqual(harness.errors, ['Formatting failed: Could not apply edits']);
+      assert.strictEqual(harness.information.length, 0);
+    });
+
+    test('replaces the content and reports a successful format', async () => {
+      let replacement = '';
+      const harness = createHarness();
+      await executeEditorCommand(
+        {
+          content: '{"a":1}',
+          to: 'json',
+          action: 'format',
+          config: { ...config, outputStyle: 'pretty' },
+          formatTarget: {
+            isStale: () => false,
+            replace: async (content) => {
+              replacement = content;
+              return true;
+            },
+          },
+        },
+        harness.dependencies,
+      );
+      assert.strictEqual(replacement, '{\n  "a": 1\n}\n');
+      assert.deepStrictEqual(harness.information, ['Formatted json (pretty)']);
+    });
+
+    test('reports a conversion error without opening a document', async () => {
+      const harness = createHarness();
+      await executeEditorCommand(
+        { content: 'not valid json or xml or yaml: {{{', to: 'yaml', action: 'convert', config },
+        harness.dependencies,
+      );
+      assert.strictEqual(harness.errors.length, 1);
+      assert.ok((harness.errors[0] ?? '').startsWith('Conversion failed: '));
+      assert.strictEqual(harness.opened.length, 0);
+    });
+  });
+
+  suite('executeClipboardCommand', () => {
+    test('rejects an empty clipboard', async () => {
+      const harness = createHarness();
+      await executeClipboardCommand({ content: ' \n ', to: 'json', config }, harness.dependencies);
+      assert.deepStrictEqual(harness.errors, ['Conversion failed: Clipboard is empty']);
+      assert.strictEqual(harness.opened.length, 0);
+    });
+
+    test('converts clipboard content and opens a document', async () => {
+      const harness = createHarness();
+      await executeClipboardCommand(
+        { content: ' {"a":1} ', to: 'json', config: { ...config, outputStyle: 'minified' } },
+        harness.dependencies,
+      );
+      assert.deepStrictEqual(harness.opened, [
+        { content: '{"a":1}', language: 'json', convertOutput: 'newTab' },
+      ]);
+      assert.deepStrictEqual(harness.information, ['Pasted clipboard as json (minified)']);
+    });
+
+    test('does nothing when the Quick Pick is cancelled', async () => {
+      const harness = createHarness({ showQuickPick: async () => undefined });
+      await executeClipboardCommand(
+        { content: '{"a":1}', to: 'json', config },
+        harness.dependencies,
+      );
+      assert.strictEqual(harness.opened.length, 0);
+      assert.strictEqual(harness.information.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Split the vscode-facing adapter in extension.ts from the command flow so the flow can be tested without an Extension Development Host:

- add extensionCore.ts with executeEditorCommand, executeClipboardCommand and the document staleness predicate, all driven through injected ports
- reduce extension.ts to command registration and the vscode bindings
- cover the command flow in src/test/unit/extension.test.ts and narrow the integration suite to behavior that needs a real VS Code host
- scope .vscode-test.mjs to out/test/integration/**
- run npm test in CI, which the .vscode-test.mjs change would otherwise drop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced reliability for conversion/formatting when the document or selection changes during user prompts.
  - Quick Pick cancellation now leaves the source document unchanged.
  - Clipboard conversion works even without an active editor; formatting is aborted when no editor is available or when the document is read-only.
  - Clearer handling for empty/invalid input and conversion/formatting failures.

- **Tests**
  - Added focused unit test coverage for conversion/formatting guards, minify resolution, and clipboard flows.
  - Narrowed VS Code integration test scope and updated CI to run unit tests before integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->