### PR TITLE
ci: cover build and packaging config in the change filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           CHANGED=$(git diff --name-only "$BASE...$HEAD")
           echo "Changed files:"
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -qE '^(src/|scripts/|package\.json$|package-lock\.json$|tsconfig\.json$|eslint\.config\.mjs$|\.github/workflows/)'; then
+          if echo "$CHANGED" | grep -qE '^(\.github/workflows/|scripts/|src/|\.vscode-test\.mjs$|\.vscodeignore$|esbuild\.js$|eslint\.config\.mjs$|package-lock\.json$|package\.json$|tsconfig\.json$)'; then
             echo "test-needed=true" >> $GITHUB_OUTPUT
           else
             echo "test-needed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
esbuild.js, .vscode-test.mjs and .vscodeignore did not match the check-changes filter, so changing only those skipped the test job -- including the Package extension step, which is the sole check for .vscodeignore. Also give the alternation a stable order: directories first, then root files, alphabetical within each group.