### PR TITLE
build: exclude .agents and .codex from the packaged extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,7 @@
 *.vsix
+.agents/**
 .claude/**
+.codex/**
 .devcontainer/**
 .github/**
 .husky/**


### PR DESCRIPTION
The newly added .agents/skills/** and .codex/config.toml were being bundled into the VSIX, as confirmed with vsce ls. They are agent tooling config, not extension runtime files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaged extension contents to exclude additional hidden agent directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->